### PR TITLE
Refactor world border collision

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/shapes/LithiumEntityCollisions.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/shapes/LithiumEntityCollisions.java
@@ -14,6 +14,7 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.ViewableWorld;
+import net.minecraft.world.border.WorldBorder;
 import net.minecraft.world.chunk.Chunk;
 
 import java.util.Spliterator;
@@ -51,13 +52,13 @@ public class LithiumEntityCollisions {
                 if (!this.skipWorldBorderCheck) {
                     this.skipWorldBorderCheck = true;
 
-                    VoxelShape border = world.getWorldBorder().asVoxelShape();
+                    WorldBorder border = world.getWorldBorder();
 
                     boolean isInsideBorder = doesEntityCollideWithWorldBorder(border, entity.getBoundingBox().contract(1.0E-7D));
                     boolean isCrossingBorder = doesEntityCollideWithWorldBorder(border, entity.getBoundingBox().expand(1.0E-7D));
 
                     if (!isInsideBorder && isCrossingBorder) {
-                        consumer.accept(border);
+                        consumer.accept(border.asVoxelShape());
 
                         return true;
                     }
@@ -131,7 +132,7 @@ public class LithiumEntityCollisions {
         return VoxelShapes.matchesAnywhere(block.offset(x, y, z), entityShape, BooleanBiFunction.AND);
     }
 
-    public static boolean doesEntityCollideWithWorldBorder(WorldBorder border, Box entityBox) {
+    public static boolean doesEntityCollideWithWorldBorder(WorldBorder border, Box ebox) {
         double wboxMinX = border.getCenterX() - (border.getSize() / 2);
         double wboxMinZ = border.getCenterZ() - (border.getSize() / 2);
 

--- a/src/main/java/me/jellysquid/mods/lithium/common/shapes/LithiumEntityCollisions.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/shapes/LithiumEntityCollisions.java
@@ -53,8 +53,8 @@ public class LithiumEntityCollisions {
 
                     VoxelShape border = world.getWorldBorder().asVoxelShape();
 
-                    boolean isInsideBorder = VoxelShapes.matchesAnywhere(border, VoxelShapes.cuboid(entity.getBoundingBox().contract(1.0E-7D)), BooleanBiFunction.AND);
-                    boolean isCrossingBorder = VoxelShapes.matchesAnywhere(border, VoxelShapes.cuboid(entity.getBoundingBox().expand(1.0E-7D)), BooleanBiFunction.AND);
+                    boolean isInsideBorder = doesEntityCollideWithWorldBorder(border, entity.getBoundingBox().contract(1.0E-7D));
+                    boolean isCrossingBorder = doesEntityCollideWithWorldBorder(border, entity.getBoundingBox().expand(1.0E-7D));
 
                     if (!isInsideBorder && isCrossingBorder) {
                         consumer.accept(border);
@@ -129,5 +129,17 @@ public class LithiumEntityCollisions {
         }
 
         return VoxelShapes.matchesAnywhere(block.offset(x, y, z), entityShape, BooleanBiFunction.AND);
+    }
+
+    public static boolean doesEntityCollideWithWorldBorder(WorldBorder border, Box entityBox) {
+        double wboxMinX = border.getCenterX() - (border.getSize() / 2);
+        double wboxMinZ = border.getCenterZ() - (border.getSize() / 2);
+
+        double wboxMaxX = border.getCenterX() + (border.getSize() / 2);
+        double wboxMaxZ = border.getCenterZ() + (border.getSize() / 2);
+
+        // Entities and world borders both use AABBs, so we can use a very simple and fast collision check
+        return wboxMinX < ebox.minX && wboxMaxX > ebox.minX && wboxMinX < ebox.maxX && wboxMaxX > ebox.maxX &&
+            wboxMinZ < ebox.minZ && wboxMaxZ > ebox.minZ && wboxMinZ < ebox.maxZ && wboxMaxZ > ebox.maxZ;
     }
 }

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/entity/simple_world_border_collisions/MixinEntity.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/entity/simple_world_border_collisions/MixinEntity.java
@@ -32,24 +32,7 @@ public abstract class MixinEntity {
         }
 
         WorldBorder border = this.world.getWorldBorder();
-
-        double wboxMinX = border.getCenterX() - (border.getSize() / 2);
-        double wboxMinZ = border.getCenterZ() - (border.getSize() / 2);
-
-        double wboxMaxX = border.getCenterX() + (border.getSize() / 2);
-        double wboxMaxZ = border.getCenterZ() + (border.getSize() / 2);
-
         Box ebox = this.getBoundingBox().stretch(motion);
-
-        // The entity's bounding box is fully within the world border and will not collide with it. We can safely remove
-        // it from the stream of shapes to do collision checking against.
-        if (wboxMinX < ebox.minX && wboxMaxX > ebox.minX && wboxMinX < ebox.maxX && wboxMaxX > ebox.maxX &&
-                wboxMinZ < ebox.minZ && wboxMaxZ > ebox.minZ && wboxMinZ < ebox.maxZ && wboxMaxZ > ebox.maxZ) {
-            return true;
-        }
-
-        return VoxelShapes.matchesAnywhere(borderShape, entityShape, func);
+        return LithiumEntityCollisions.doesEntityCollideWithWorldBorder(border, ebox);
     }
-
-
 }

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/entity/simple_world_border_collisions/MixinEntity.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/entity/simple_world_border_collisions/MixinEntity.java
@@ -1,6 +1,7 @@
 package me.jellysquid.mods.lithium.mixin.entity.simple_world_border_collisions;
 
 import me.jellysquid.mods.lithium.common.LithiumMod;
+import me.jellysquid.mods.lithium.common.shapes.LithiumEntityCollisions;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.BooleanBiFunction;
 import net.minecraft.util.math.Box;


### PR DESCRIPTION
This PR moves the optimized world border collision code into the `LithiumEntityCollisions` class, which allows it to be used in the general entity collision optimizations.