### PR TITLE
Fixed #29 Lithium breaks stray cat behavior.

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/entity/tracker/nearby/NearbyEntityTracker.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/entity/tracker/nearby/NearbyEntityTracker.java
@@ -1,6 +1,8 @@
 package me.jellysquid.mods.lithium.common.entity.tracker.nearby;
 
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.ai.TargetPredicate;
+import net.minecraft.util.math.Box;
 import net.minecraft.util.math.MathHelper;
 
 import java.util.HashSet;
@@ -51,7 +53,15 @@ public class NearbyEntityTracker<T extends LivingEntity> implements NearbyEntity
         this.nearby.remove((T) entity);
     }
 
-    public T getClosestEntity() {
+    /**
+     * Gets the closest T (extends LivingEntity) to the center of this tracker that also intersects with the given box and meets the
+     * requirements of the targetPredicate.
+     * The result may be different from vanilla if there are multiple closest entities.
+     * @param box the box the entities have to intersect
+     * @param targetPredicate predicate the entity has to meet
+     * @return the closest Entity that meets all requirements (distance, box intersection, predicate, type T)
+     */
+    public T getClosestEntity(Box box, TargetPredicate targetPredicate) {
         double x = this.self.getX();
         double y = this.self.getY();
         double z = this.self.getZ();
@@ -62,7 +72,7 @@ public class NearbyEntityTracker<T extends LivingEntity> implements NearbyEntity
         for (T entity : this.nearby) {
             double distance = entity.squaredDistanceTo(x, y, z);
 
-            if (distance < nearestDistance) {
+            if (distance < nearestDistance && (box == null || box.intersects(entity.getBoundingBox())) && targetPredicate.test(this.self, entity)) {
                 nearest = entity;
                 nearestDistance = distance;
             }

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/ai/nearby_entity_tracking/goals/MixinFleeEntityGoal.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/ai/nearby_entity_tracking/goals/MixinFleeEntityGoal.java
@@ -29,6 +29,6 @@ public class MixinFleeEntityGoal<T extends LivingEntity> {
 
     @Redirect(method = "canStart", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getClosestEntityIncludingUngeneratedChunks(Ljava/lang/Class;Lnet/minecraft/entity/ai/TargetPredicate;Lnet/minecraft/entity/LivingEntity;DDDLnet/minecraft/util/math/Box;)Lnet/minecraft/entity/LivingEntity;"))
     private T redirectGetNearestEntity(World world, Class<? extends T> entityClass, TargetPredicate targetPredicate, LivingEntity entity, double x, double y, double z, Box box) {
-        return this.tracker.getClosestEntity();
+        return this.tracker.getClosestEntity(box, targetPredicate);
     }
 }

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/ai/nearby_entity_tracking/goals/MixinLookAtGoal.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/ai/nearby_entity_tracking/goals/MixinLookAtGoal.java
@@ -28,11 +28,11 @@ public class MixinLookAtGoal {
 
     @Redirect(method = "canStart", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getClosestEntityIncludingUngeneratedChunks(Ljava/lang/Class;Lnet/minecraft/entity/ai/TargetPredicate;Lnet/minecraft/entity/LivingEntity;DDDLnet/minecraft/util/math/Box;)Lnet/minecraft/entity/LivingEntity;"))
     private <T extends LivingEntity> LivingEntity redirectGetClosestEntity(World world, Class<? extends T> entityClass, TargetPredicate targetPredicate, LivingEntity entity, double x, double y, double z, Box box) {
-        return this.tracker.getClosestEntity();
+        return this.tracker.getClosestEntity(box, targetPredicate);
     }
 
     @Redirect(method = "canStart", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getClosestPlayer(Lnet/minecraft/entity/ai/TargetPredicate;Lnet/minecraft/entity/LivingEntity;DDD)Lnet/minecraft/entity/player/PlayerEntity;"))
     private PlayerEntity redirectGetClosestPlayer(World world, TargetPredicate targetPredicate, LivingEntity entity, double x, double y, double z) {
-        return (PlayerEntity) this.tracker.getClosestEntity();
+        return (PlayerEntity) this.tracker.getClosestEntity(null, targetPredicate);
     }
 }


### PR DESCRIPTION
The cause of the bug is that the entity tracker is not checking whether the predicate returns true when evaluating which entity is the closest. The predicate is usually responsible for filtering out certain entities (spectators, or sometimes entities that cannot be seen using raycast, entities on the same team). Not testing the predicate leads to incorrect behavior, as for example, cats usually can't flee from spectators or creative mode players.

The fix adds checking the predicate and the given box (tracking distance of most things is only +-3 on the y axis) after the minimal distance criterion.

Of course this fix will cost some performance, but I don't see a way to get around evaluating the predicate more often than absolutely necessary without sorting the entities by distance first. Also caching the result does not seem viable, because keeping track when the cached value becomes outdated would be required.