### PR TITLE
Fix Creepers sometimes not pathfinding to the player caused by incorrect chunk cache initialization

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/ai/pathing/MixinChunkCache.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/ai/pathing/MixinChunkCache.java
@@ -45,8 +45,8 @@ public class MixinChunkCache {
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void init(World world, BlockPos minPos, BlockPos maxPos, CallbackInfo ci) {
-        this.xLen = (maxPos.getX() - minPos.getX()) >> 4;
-        this.zLen = (maxPos.getZ() - minPos.getZ()) >> 4;
+        this.xLen = 1 + (maxPos.getX() >> 4) - (minPos.getX() >> 4);
+        this.zLen = 1 + (maxPos.getZ() >> 4) - (minPos.getZ() >> 4);
 
         this.chunksFlat = new Chunk[this.xLen * this.zLen];
 


### PR DESCRIPTION
Lithiums flattened chunk cache is initialized with the wrong size (too small by 1 or 2 chunks in both directions). Therefore important chunks for mob navigation are missing in the cache, and assumed to be air, which will make the mob not walk like in vanilla. On discord there was a report of one creeper not tracking the player, I reproduced this and the corrected chunk cache size is fixing it.