### PR TITLE
Allow hotswapping by removing "switch on enum" in mixin classes.

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/math/fast_util/MixinAxisCycleDirection.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/math/fast_util/MixinAxisCycleDirection.java
@@ -11,6 +11,14 @@ import org.spongepowered.asm.mixin.Overwrite;
  */
 @Mixin(AxisCycleDirection.class)
 public class MixinAxisCycleDirection {
+
+    static {
+        assert Direction.Axis.X.ordinal() == 0;
+        assert Direction.Axis.Y.ordinal() == 1;
+        assert Direction.Axis.Z.ordinal() == 2;
+        assert Direction.Axis.values().length == 3;
+    }
+
     @Mixin(targets = "net/minecraft/util/math/AxisCycleDirection$2")
     public static class MixinForward {
         /**
@@ -19,12 +27,12 @@ public class MixinAxisCycleDirection {
          */
         @Overwrite
         public Direction.Axis cycle(Direction.Axis axis) {
-            switch (axis) {
-                case X:
+            switch (axis.ordinal()) {
+                case 0: //X
                     return Direction.Axis.Y;
-                case Y:
+                case 1: //Y
                     return Direction.Axis.Z;
-                case Z:
+                case 2: //Z
                     return Direction.Axis.X;
             }
 
@@ -40,12 +48,12 @@ public class MixinAxisCycleDirection {
          */
         @Overwrite
         public Direction.Axis cycle(Direction.Axis axis) {
-            switch (axis) {
-                case X:
+            switch (axis.ordinal()) {
+                case 0: //X
                     return Direction.Axis.Z;
-                case Y:
+                case 1: //Y
                     return Direction.Axis.X;
-                case Z:
+                case 2: //Z
                     return Direction.Axis.Y;
             }
 

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/math/fast_util/MixinBox.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/math/fast_util/MixinBox.java
@@ -9,6 +9,14 @@ import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(Box.class)
 public class MixinBox {
+
+    static {
+        assert Direction.Axis.X.ordinal() == 0;
+        assert Direction.Axis.Y.ordinal() == 1;
+        assert Direction.Axis.Z.ordinal() == 2;
+        assert Direction.Axis.values().length == 3;
+    }
+
     @Shadow
     @Final
     public double x1;
@@ -39,12 +47,12 @@ public class MixinBox {
      */
     @Overwrite
     public double getMin(Direction.Axis axis) {
-        switch (axis) {
-            case X:
+        switch (axis.ordinal()) {
+            case 0: //X
                 return this.x1;
-            case Y:
+            case 1: //Y
                 return this.y1;
-            case Z:
+            case 2: //Z
                 return this.z1;
         }
 
@@ -57,12 +65,12 @@ public class MixinBox {
      */
     @Overwrite
     public double getMax(Direction.Axis axis) {
-        switch (axis) {
-            case X:
+        switch (axis.ordinal()) {
+            case 0: //X
                 return this.x2;
-            case Y:
+            case 1: //Y
                 return this.y2;
-            case Z:
+            case 2: //Z
                 return this.z2;
         }
 


### PR DESCRIPTION
Hotswapping failed probably due to the class required for switch on enum: https://www.benf.org/other/cfr/switch-on-enum.html

After following the tutorial at https://fabricmc.net/wiki/tutorial:mixin_hotswaps . I still couldn't hotswap mixins in lithium, while it works perfectly fine for other mods. From my testing it looks like that using switch on enum in mixin classes breaks hotswap. After replacing the switch on enum with switching on the ordinal integer hotswap is working again.