### PR TITLE
Evaluate getEntityCollisions lazily and place block collisions earlier in the stream

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/entity/stream_entity_collisions_lazily/MixinEntity.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/entity/stream_entity_collisions_lazily/MixinEntity.java
@@ -15,22 +15,6 @@ import java.util.stream.Stream;
 @Mixin(Entity.class)
 public class MixinEntity {
     /**
-     * Redirect to allow skipping getting entities from world when the stream isn't used.
-     * The resulting stream will only evaluate the getEntityCollisions lambda when it is queried.
-     *
-     * The intended usecase are entities standing on the ground:
-     * Their gravity movement is completely blocked by the block below, querying entity collisions can't
-     * affect the movement anymore
-     */
-    @Redirect(method = "adjustMovementForCollisions(Lnet/minecraft/util/math/Vec3d;)Lnet/minecraft/util/math/Vec3d;",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getEntityCollisions(Lnet/minecraft/entity/Entity;Lnet/minecraft/util/math/Box;Ljava/util/function/Predicate;)Ljava/util/stream/Stream;"))
-    private Stream<VoxelShape> getLazyEntityCollisionStream(World world, Entity entity_1, Box box_1, Predicate<Entity> predicate_1) {
-        Stream<Supplier<Stream<VoxelShape>>> getCollisionsLazilyStream = Stream.of(() -> entity_1.world.getEntityCollisions(entity_1, box_1, predicate_1));
-        //flatmap will only evaluate the supplier when the stream is reaching it. Won't be evaluated when block collisions cancel all movement before!
-        return getCollisionsLazilyStream.flatMap(Supplier::get);
-    }
-
-    /**
      * Redirect to try to collide with world border first, so the entity stream doesn't have to be used when other collisions cancel the whole movement already.
      */
     @Redirect(method = "adjustMovementForCollisions(Lnet/minecraft/util/math/Vec3d;)Lnet/minecraft/util/math/Vec3d;",

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/entity/stream_entity_collisions_lazily/MixinEntity.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/entity/stream_entity_collisions_lazily/MixinEntity.java
@@ -1,0 +1,51 @@
+package me.jellysquid.mods.lithium.mixin.entity.stream_entity_collisions_lazily;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+@Mixin(Entity.class)
+public class MixinEntity {
+    /**
+     * Redirect to allow skipping getting entities from world when the stream isn't used.
+     * The resulting stream will only evaluate the getEntityCollisions lambda when it is queried.
+     *
+     * The intended usecase are entities standing on the ground:
+     * Their gravity movement is completely blocked by the block below, querying entity collisions can't
+     * affect the movement anymore
+     */
+    @Redirect(method = "adjustMovementForCollisions(Lnet/minecraft/util/math/Vec3d;)Lnet/minecraft/util/math/Vec3d;",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getEntityCollisions(Lnet/minecraft/entity/Entity;Lnet/minecraft/util/math/Box;Ljava/util/function/Predicate;)Ljava/util/stream/Stream;"))
+    private Stream<VoxelShape> getLazyEntityCollisionStream(World world, Entity entity_1, Box box_1, Predicate<Entity> predicate_1) {
+        Stream<Supplier<Stream<VoxelShape>>> getCollisionsLazilyStream = Stream.of(() -> entity_1.world.getEntityCollisions(entity_1, box_1, predicate_1));
+        //flatmap will only evaluate the supplier when the stream is reaching it. Won't be evaluated when block collisions cancel all movement before!
+        return getCollisionsLazilyStream.flatMap(Supplier::get);
+    }
+
+    /**
+     * Redirect to try to collide with world border first, so the entity stream doesn't have to be used when other collisions cancel the whole movement already.
+     */
+    @Redirect(method = "adjustMovementForCollisions(Lnet/minecraft/util/math/Vec3d;)Lnet/minecraft/util/math/Vec3d;",
+            at = @At(value = "INVOKE", target = "Ljava/util/stream/Stream;concat(Ljava/util/stream/Stream;Ljava/util/stream/Stream;)Ljava/util/stream/Stream;"))
+    private Stream<VoxelShape> reorderStreams_WorldBorderCollisionsFirst(Stream<? extends VoxelShape> entityShapes, Stream<? extends VoxelShape> blockShapes){
+        return Stream.concat(blockShapes, entityShapes);
+    }
+
+
+    /**
+     * Redirect to try to collide with blocks first, so the entity stream doesn't have to be used when block collisions cancel the whole movement already.
+     */
+    @Redirect(method = "adjustMovementForCollisions(Lnet/minecraft/entity/Entity;Lnet/minecraft/util/math/Vec3d;Lnet/minecraft/util/math/Box;Lnet/minecraft/world/World;Lnet/minecraft/block/ShapeContext;Lnet/minecraft/util/collection/ReusableStream;)Lnet/minecraft/util/math/Vec3d;",
+            at = @At(value = "INVOKE", target = "Ljava/util/stream/Stream;concat(Ljava/util/stream/Stream;Ljava/util/stream/Stream;)Ljava/util/stream/Stream;"))
+    private static Stream<VoxelShape> reorderStreams_BlockCollisionsFirst(Stream<? extends VoxelShape> entityShapes, Stream<? extends VoxelShape> blockShapes){
+        return Stream.concat(blockShapes, entityShapes);
+    }
+}

--- a/src/main/resources/lithium.mixins.json
+++ b/src/main/resources/lithium.mixins.json
@@ -48,6 +48,7 @@
         "entity.collisions.MixinEntityView",
         "entity.data_tracker.no_locks.MixinDataTracker",
         "entity.data_tracker.use_arrays.MixinDataTracker",
+        "entity.stream_entity_collisions_lazily.MixinEntity",
         "gen.chunk_region.MixinChunkRegion",
         "math.fast_util.MixinAxisCycleDirection",
         "math.fast_util.MixinAxisCycleDirection$MixinBackward",


### PR DESCRIPTION
Getting entities from the world is a hotspot in movement collision code. As most movements are just caused by gravity and are cancelled as soon as the collision with the block below the entity is checked, I suggest not getting entity collision shapes from the world at all, if blocks already stop the movement completely.
For this two things have to be done:
- In the collision voxelshape stream the block collisions have to be earlier than the entity collisions.
- If the entity collisions in the stream aren't used, don't get the entities from the world.

The 2nd one seems to be a bit tricky, but one solution is to use a supplier lamda that captures the arguments for the getEntityCollisions call and use the lazy evaluation of flatMap: Stream.of(supplierLamda).flatMap(Supplier::get)

In my test with a 101x101 grid of armorstands standing on the ground, this optimization brought the 145mspt down to 60mspt. In that case of non moving entities the flatMap is never evaluated (breakpoint not hit).