### PR TITLE
new: Optimize entity data tracker

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/entity/data_tracker/iteration/MixinDataTracker.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/entity/data_tracker/iteration/MixinDataTracker.java
@@ -1,0 +1,36 @@
+package me.jellysquid.mods.lithium.mixin.entity.data_tracker.iteration;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.data.DataTracker;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Map;
+
+/**
+ * Replacing the {@link DataTracker} entries map with {@link Int2ObjectOpenHashMap} will
+ * reduce overall memory consumption and speed up the iteration process.
+ */
+@Mixin(value = DataTracker.class, priority = 999)
+public class MixinDataTracker {
+    @Mutable
+    @Shadow
+    @Final
+    private Map<Integer, DataTracker.Entry<?>> entries;
+
+    /**
+     * This replaces entity data tracker entries map to a much quicker variant.
+     *
+     * @author Maity
+     */
+    @Inject(method = "<init>", at = @At("RETURN"))
+    private void init(Entity entity, CallbackInfo ci) {
+        this.entries = new Int2ObjectOpenHashMap<>(this.entries);
+    }
+}

--- a/src/main/resources/lithium.mixins.json
+++ b/src/main/resources/lithium.mixins.json
@@ -46,6 +46,7 @@
         "entity.collisions.MixinCollisionView",
         "entity.collisions.MixinEntity",
         "entity.collisions.MixinEntityView",
+        "entity.data_tracker.iteration.MixinDataTracker",
         "entity.data_tracker.no_locks.MixinDataTracker",
         "entity.data_tracker.use_arrays.MixinDataTracker",
         "gen.chunk_region.MixinChunkRegion",


### PR DESCRIPTION
The DataTracker `HashMap` entries map can be replaced with a faster `Int2ObjectOpenHashMap`, which optimizes the iteration process and also reduces memory consumption.