### PR TITLE
Use faster cache implementation for isShapeFullCube check

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/util/collections/Object2BooleanCacheTable.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/util/collections/Object2BooleanCacheTable.java
@@ -1,0 +1,61 @@
+package me.jellysquid.mods.lithium.common.util.collections;
+
+import it.unimi.dsi.fastutil.HashCommon;
+import net.minecraft.util.math.MathHelper;
+
+import java.util.function.Predicate;
+
+/**
+ * A lossy hashtable implementation that stores a mapping between an object and a boolean.
+ *
+ * Any hash collisions will result in an overwrite: this is safe because the correct value can always be recomputed,
+ * given that the given operator is deterministic.
+ *
+ * This implementation is safe to use from multiple threads
+ */
+public final class Object2BooleanCacheTable<T> {
+    private final int capacity;
+    private final int mask;
+
+    private final Node<T>[] nodes;
+
+    private final Predicate<T> operator;
+
+    @SuppressWarnings("unchecked")
+    public Object2BooleanCacheTable(int capacity, Predicate<T> operator) {
+        this.capacity = MathHelper.smallestEncompassingPowerOfTwo(capacity);
+        this.mask = this.capacity - 1;
+
+        this.nodes = (Node<T>[]) new Node[this.capacity];
+
+        this.operator = operator;
+    }
+
+    private static <T> int hash(T key) {
+        return HashCommon.mix(key.hashCode());
+    }
+
+    public boolean get(T key) {
+        int idx = hash(key) & this.mask;
+
+        Node<T> node = this.nodes[idx];
+        if (node != null && key.equals(node.key)) {
+            return node.value;
+        }
+
+        boolean test = this.operator.test(key);
+        this.nodes[idx] = new Node<>(key, test);
+
+        return test;
+    }
+
+    static class Node<T> {
+        final T key;
+        final boolean value;
+
+        Node(T key, boolean value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
+}

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/shapes/blockstate_cache/MixinBlock.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/shapes/blockstate_cache/MixinBlock.java
@@ -3,10 +3,14 @@ package me.jellysquid.mods.lithium.mixin.shapes.blockstate_cache;
 import me.jellysquid.mods.lithium.common.block.BlockShapeCacheExtended;
 import me.jellysquid.mods.lithium.common.block.BlockShapeCacheExtendedProvider;
 import me.jellysquid.mods.lithium.common.block.BlockShapeHelper;
+import me.jellysquid.mods.lithium.common.util.collections.Object2BooleanCacheTable;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.util.function.BooleanBiFunction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.WorldView;
 import org.spongepowered.asm.mixin.Mixin;
@@ -18,6 +22,11 @@ import org.spongepowered.asm.mixin.Overwrite;
  */
 @Mixin(Block.class)
 public class MixinBlock {
+    private static final Object2BooleanCacheTable<VoxelShape> FULL_CUBE_CACHE = new Object2BooleanCacheTable<>(
+            512,
+            shape -> !VoxelShapes.matchesAnywhere(VoxelShapes.fullCube(), shape, BooleanBiFunction.NOT_SAME)
+    );
+
     /**
      * @reason Use the shape cache
      * @author JellySquid
@@ -48,5 +57,14 @@ public class MixinBlock {
         }
 
         return BlockShapeHelper.sideCoversSquare(state.getCollisionShape(world, pos).getFace(side), BlockShapeHelper.SOLID_SMALL_SQUARE_SHAPE);
+    }
+
+    /**
+     * @reason Use a faster cache implementation
+     * @author gegy1000
+     */
+    @Overwrite
+    public static boolean isShapeFullCube(VoxelShape shape) {
+        return FULL_CUBE_CACHE.get(shape);
     }
 }


### PR DESCRIPTION
This change mainly affects vine generation, which calls `Block.isShapeFullCube` extensively. Because so many vines are placed in jungles, this can create a noticeable improvement in jungle generation speed.

Here's some pretty rough profiler results when generating a jungle:

Before
![Before](https://i.imgur.com/JZKsPe9.png)

After
![After](https://i.imgur.com/vACjG9u.png)