### PR TITLE
fix: stacked tnt explode at the wrong height #66

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/world/explosions/MixinExplosion.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/world/explosions/MixinExplosion.java
@@ -7,6 +7,7 @@ import net.minecraft.block.Blocks;
 import net.minecraft.enchantment.ProtectionEnchantment;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.TntEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.FluidState;
@@ -288,7 +289,9 @@ public abstract class MixinExplosion {
             }
 
             double distXSq = entity.getX() - this.x;
-            double distYSq = entity.getEyeY() - this.y;
+            // [VanillaCopy] In the 1.16 snapshots Mojang added this distinction between TNT and other entities in the explosion code to
+            // fix the the increased eye height affecting explosions. The eye height increase was an attempt to fix rendering of tnt on soulsand.
+            double distYSq = (entity instanceof TntEntity ? entity.getY() : entity.getEyeY()) - this.y;
             double distZSq = entity.getZ() - this.z;
 
             double dist = MathHelper.sqrt((distXSq * distXSq) + (distYSq * distYSq) + (distZSq * distZSq));


### PR DESCRIPTION
In the 1.16 snapshots Mojang added a distinction between TNT and other entities in the explosion code to fix the the increased eye height affecting explosions. The eye height increase was an attempt to fix rendering of tnt on soulsand.
This pullrequest adds the behavior to lithium, which is necessary as lithium overwrites the minecraft explosion code.

Thanks to @pwouik for reporting #66 .

Here is a testworld for this (summon stacked tnt on a clock, with pauses in between).
[lithium #66.zip](https://github.com/jellysquid3/lithium-fabric/files/4870459/lithium.66.zip)
