### PR TITLE
Mod overrides for config values

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/config/LithiumConfig.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/config/LithiumConfig.java
@@ -4,6 +4,10 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.CustomValue;
+import net.fabricmc.loader.api.metadata.ModMetadata;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -18,6 +22,8 @@ import java.util.Properties;
 @SuppressWarnings("CanBeFinal")
 public class LithiumConfig {
     private static final Logger LOGGER = LogManager.getLogger("LithiumConfig");
+
+    private static final String JSON_KEY_LITHIUM_OPTIONS = "lithium:options";
 
     private final Map<String, Option> options = new HashMap<>();
 
@@ -96,6 +102,43 @@ public class LithiumConfig {
         }
     }
 
+    private void applyModOverrides() {
+        for (ModContainer container : FabricLoader.getInstance().getAllMods()) {
+            ModMetadata meta = container.getMetadata();
+            if (meta.containsCustomValue(JSON_KEY_LITHIUM_OPTIONS)) {
+                CustomValue lithiumOverrides = meta.getCustomValue(JSON_KEY_LITHIUM_OPTIONS);
+                if (lithiumOverrides.getType() != CustomValue.CvType.OBJECT) {
+                    LOGGER.warn("Mod '{}' contains invalid lithium option overrides, ignoring", meta.getId());
+                    continue;
+                }
+
+                for (Map.Entry<String, CustomValue> entry : lithiumOverrides.getAsObject()) {
+                    String optionName = entry.getKey();
+                    Option option = this.options.get(optionName);
+
+                    if (option == null) {
+                        LOGGER.warn("Mod '{}' attempted to override option '{}', which doesn't exist, ignoring", meta.getId(), optionName);
+                        continue;
+                    }
+
+                    if (entry.getValue().getType() != CustomValue.CvType.BOOLEAN) {
+                        LOGGER.warn("Mod '{}' attempted to override option '{}' with an invalid value, ignoring", meta.getId(), optionName);
+                        continue;
+                    }
+
+                    boolean enabled = entry.getValue().getAsBoolean();
+                    // disabling the option takes precedence over enabling
+                    if (!enabled && option.isEnabled()) {
+                        option.clearModsDefiningValue();
+                    }
+                    if (!enabled || option.isEnabled() || option.getModsDefiningValue().isEmpty()) {
+                        option.addModOverride(enabled, meta.getId());
+                    }
+                }
+            }
+        }
+    }
+
     /**
      * Returns the most specific Mixin rule for the specified class name.
      */
@@ -147,6 +190,7 @@ public class LithiumConfig {
         LithiumConfig config = new LithiumConfig();
         config.discoverMixins(mixinPath);
         config.read(props);
+        config.applyModOverrides();
 
         return config;
     }
@@ -183,7 +227,7 @@ public class LithiumConfig {
     public int getOptionOverrideCount() {
         return (int) this.options.values()
                 .stream()
-                .filter(Option::isUserDefined)
+                .filter(option -> option.isUserDefined() || !option.getModsDefiningValue().isEmpty())
                 .count();
     }
 }

--- a/src/main/java/me/jellysquid/mods/lithium/common/config/LithiumConfig.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/config/LithiumConfig.java
@@ -108,7 +108,7 @@ public class LithiumConfig {
             if (meta.containsCustomValue(JSON_KEY_LITHIUM_OPTIONS)) {
                 CustomValue lithiumOverrides = meta.getCustomValue(JSON_KEY_LITHIUM_OPTIONS);
                 if (lithiumOverrides.getType() != CustomValue.CvType.OBJECT) {
-                    LOGGER.warn("Mod '{}' contains invalid lithium option overrides, ignoring", meta.getId());
+                    LOGGER.warn("Mod '{}' contains invalid Lithium option overrides, ignoring", meta.getId());
                     continue;
                 }
 

--- a/src/main/java/me/jellysquid/mods/lithium/common/config/Option.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/config/Option.java
@@ -1,8 +1,13 @@
 package me.jellysquid.mods.lithium.common.config;
 
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 public class Option {
     private boolean enabled;
     private boolean userDefined;
+    private Set<String> modDefined = new LinkedHashSet<>(0);
 
     public Option(boolean enabled, boolean userDefined) {
         this.enabled = enabled;
@@ -14,11 +19,24 @@ public class Option {
         this.userDefined = userDefined;
     }
 
+    public void addModOverride(boolean enabled, String modId) {
+        this.enabled = false;
+        this.modDefined.add(modId);
+    }
+
     public boolean isEnabled() {
         return this.enabled;
     }
 
     public boolean isUserDefined() {
         return this.userDefined;
+    }
+
+    public void clearModsDefiningValue() {
+        this.modDefined.clear();
+    }
+
+    public Collection<String> getModsDefiningValue() {
+        return this.modDefined;
     }
 }

--- a/src/main/java/me/jellysquid/mods/lithium/common/config/Option.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/config/Option.java
@@ -20,7 +20,7 @@ public class Option {
     }
 
     public void addModOverride(boolean enabled, String modId) {
-        this.enabled = false;
+        this.enabled = enabled;
         this.modDefined.add(modId);
     }
 

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/LithiumMixinPlugin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/LithiumMixinPlugin.java
@@ -50,7 +50,13 @@ public class LithiumMixinPlugin implements IMixinConfigPlugin {
         String mixin = mixinClassName.substring(MIXIN_PACKAGE_ROOT.length());
         Option option = this.config.getOptionForMixin(mixin);
 
-        if (option.isUserDefined()) {
+        if (!option.getModsDefiningValue().isEmpty()) {
+            if (option.isEnabled()) {
+                this.logger.warn("Applying mixin '{}' as mod(s) {} forcefully enable it", mixin, option.getModsDefiningValue());
+            } else {
+                this.logger.warn("Not applying mixin '{}' as mod(s) {} forcefully disable it", mixin, option.getModsDefiningValue());
+            }
+        } else if (option.isUserDefined()) {
             if (option.isEnabled()) {
                 this.logger.warn("Applying mixin '{}' as user configuration forcefully enables it", mixin);
             } else {

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/LithiumMixinPlugin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/LithiumMixinPlugin.java
@@ -29,7 +29,7 @@ public class LithiumMixinPlugin implements IMixinConfigPlugin {
             throw new RuntimeException("Could not load configuration file for Lithium", e);
         }
 
-        this.logger.info("Loaded configuration file for Lithium ({} options available, {} user overrides)",
+        this.logger.info("Loaded configuration file for Lithium ({} options available, {} overrides)",
                 this.config.getOptionCount(), this.config.getOptionOverrideCount());
         this.logger.info("Lithium has been successfully discovered and initialized -- your game is now faster!");
 


### PR DESCRIPTION
Closes #8

This PR adds the ability for other mods to override lithium config values from their `fabric.mod.json`s, in particular to fix incompatibility issues, so the hassle isn't left to the end user.

The format for doing this is as follows:
```json
{
  "custom": {
    "lithium:options": {
      "chunk.no_locking": true,
      "mixin.entity.data_tracker.use_arrays": false
    }
  }
}
```
In the above example, this mod is force-enabling chunk no locking and force-disabling the entity tracker array optimization. If one mod tries to force-enable an option, and another mod tries to force-disable it, the mod which is disabling the option wins. Mod option overrides take precedence over user overrides. The mod ids of all mods force enabling/disabling each option are logged to the console.