### PR TITLE
fix: wrong range calculation in NearbyEntityTracker constructor

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/entity/tracker/nearby/NearbyEntityTracker.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/entity/tracker/nearby/NearbyEntityTracker.java
@@ -25,7 +25,7 @@ public class NearbyEntityTracker<T extends LivingEntity> implements NearbyEntity
         this.clazz = clazz;
         this.self = self;
         this.rangeSq = range * range;
-        this.rangeC = Math.min(MathHelper.ceil(range) >> 4, 1);
+        this.rangeC = Math.max((MathHelper.ceil(range) + 15) >> 4, 1);
     }
 
     @Override


### PR DESCRIPTION
#75 seems to be caused by the change in https://github.com/jellysquid3/lithium-fabric/commit/88beba0a70f08953501491abc5b69e68e834ffb6#diff-c7e7b07704f15208afde4c60c807139f

This PR fixes #75 .