### PR TITLE
fix: add hitboxes inside some voxelshapes of cuboids

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/shapes/VoxelShapeAlignedCuboid.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/shapes/VoxelShapeAlignedCuboid.java
@@ -1,0 +1,129 @@
+package me.jellysquid.mods.lithium.common.shapes;
+
+import net.minecraft.util.math.AxisCycleDirection;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.shape.VoxelSet;
+import net.minecraft.util.shape.VoxelShape;
+
+/**
+ * An efficient implementation of {@link VoxelShape} for a shape with one simple cuboid.
+ * This is an alternative to VoxelShapeSimpleCube with extra hitboxes inside.
+ * Vanilla has extra hitboxes at steps of 1/8th or 1/4th of a block depending on the exact coordinates of the shape.
+ * We are mimicking the effect on collisions here, as otherwise some contraptions would not behave like vanilla.
+ * @author 2No2Name
+ */
+public class VoxelShapeAlignedCuboid extends VoxelShapeSimpleCube {
+    //EPSILON for use in cases where it must be a lot smaller than 1/256 and larger than EPSILON
+    static final double LARGE_EPSILON = 10 * EPSILON;
+
+    //In bit aligned shapes the bitset adds segments are between minX/Y/Z and maxX/Y/Z.
+    //Segments all have the same size. There is an additional collision box between two adjacent segments (if both are inside the shape)
+    protected final int xSegments;
+    protected final int ySegments;
+    protected final int zSegments;
+
+    public VoxelShapeAlignedCuboid(VoxelSet voxels, double minX, double minY, double minZ, double maxX, double maxY, double maxZ, int xRes, int yRes, int zRes) {
+        super(voxels, minX, minY, minZ, maxX, maxY, maxZ);
+        //If the VoxelShape doesn't contain any extra collision boxes in vanilla on the given axis (only one segment in total)
+        //We set the segment count to 1 to signal that there are no inside shape segment borders, which is the fast branch in calculatePenetration
+        this.xSegments = xRes <= 1 ? 1 : (1 << xRes);
+        this.ySegments = yRes <= 1 ? 1 : (1 << yRes);
+        this.zSegments = zRes <= 1 ? 1 : (1 << zRes);
+    }
+
+    /**
+     * Constructor for use in offset() calls.
+     */
+    public VoxelShapeAlignedCuboid(VoxelSet voxels, int xSegments, int ySegments, int zSegments, double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+        super(voxels, minX, minY, minZ, maxX, maxY, maxZ);
+
+        this.xSegments = xSegments;
+        this.ySegments = ySegments;
+        this.zSegments = zSegments;
+    }
+
+    @Override
+    public VoxelShape offset(double x, double y, double z) {
+        return new VoxelShapeAlignedCuboid_Offset(this, this.voxels, x, y, z);
+    }
+
+
+    @Override
+    public double calculateMaxDistance(AxisCycleDirection cycleDirection, Box box, double maxDist) {
+        if (Math.abs(maxDist) < EPSILON) {
+            return 0.0D;
+        }
+
+        double penetration = this.calculatePenetration(cycleDirection, box, maxDist);
+
+        if ((penetration != maxDist) && this.intersects(cycleDirection, box)) {
+            return penetration;
+        }
+
+        return maxDist;
+    }
+
+    private double calculatePenetration(AxisCycleDirection dir, Box box, double maxDist) {
+        switch (dir) {
+            case NONE:
+                return VoxelShapeAlignedCuboid.calculatePenetration(this.minX, this.maxX, this.xSegments, box.minX, box.maxX, maxDist);
+            case FORWARD:
+                return VoxelShapeAlignedCuboid.calculatePenetration(this.minZ, this.maxZ, this.zSegments, box.minZ, box.maxZ, maxDist);
+            case BACKWARD:
+                return VoxelShapeAlignedCuboid.calculatePenetration(this.minY, this.maxY, this.ySegments, box.minY, box.maxY, maxDist);
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    /**
+     * Determine how far the movement is possible.
+     */
+    private static double calculatePenetration(double aMin, double aMax, final int segmentsPerUnit, double bMin, double bMax, double maxDist) {
+        double gap;
+
+        if (maxDist > 0.0D) {
+            gap = aMin - bMax;
+
+            if (gap >= -EPSILON) {
+                //outside the shape/within margin, move up to/back to boundary
+                return Math.min(gap, maxDist);
+            } else {
+                //already far enough inside this shape to not collide with the surface
+                if (segmentsPerUnit == 1) {
+                    //no extra segments to collide with, because only one segment in total
+                    return maxDist;
+                }
+                //extra segment walls / hitboxes inside this shape, evenly spaced out in 0..1
+                //round to the next segment wall, but with epsilon margin like vanilla
+                double wallPos = MathHelper.ceil((bMax - EPSILON) * segmentsPerUnit) / (double)segmentsPerUnit;
+                //only use the wall when it is actually inside the shape, and not a border / outside the shape
+                if (wallPos < aMax - LARGE_EPSILON)
+                    return Math.min(maxDist, wallPos - bMax);
+                return maxDist;
+            }
+        } else {
+            //whole code again, just negated for the other direction
+            gap = aMax - bMin;
+
+            if (gap <= EPSILON) {
+                //outside the shape/within margin, move up to/back to boundary
+                return Math.max(gap, maxDist);
+            } else {
+                //already far enough inside this shape to not collide with the surface
+                if (segmentsPerUnit == 1) {
+                    //no extra segments to collide with, because only one segment in total
+                    return maxDist;
+                }
+                //extra segment walls / hitboxes inside this shape, evenly spaced out in 0..1
+                //round to the next segment wall, but with epsilon margin like vanilla
+                double wallPos = MathHelper.floor((bMin + EPSILON) * segmentsPerUnit) / (double)segmentsPerUnit;
+                //only use the wall when it is actually inside the shape, and not a border / outside the shape
+                if (wallPos > aMin + LARGE_EPSILON)
+                    return Math.max(maxDist, wallPos - bMin);
+                return maxDist;
+            }
+        }
+    }
+}

--- a/src/main/java/me/jellysquid/mods/lithium/common/shapes/VoxelShapeAlignedCuboid_Offset.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/shapes/VoxelShapeAlignedCuboid_Offset.java
@@ -1,0 +1,129 @@
+package me.jellysquid.mods.lithium.common.shapes;
+
+import net.minecraft.util.math.AxisCycleDirection;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.shape.VoxelSet;
+import net.minecraft.util.shape.VoxelShape;
+
+public class VoxelShapeAlignedCuboid_Offset extends VoxelShapeAlignedCuboid {
+    //keep track on how much the voxelSet was offset. minX,maxX,minY are stored offset already
+    //This is only required to calculate the position of the walls inside the VoxelShape.
+    //For shapes that are not offset the alignment is 0, but for offset shapes the walls move together with the shape.
+    private final double xOffset, yOffset, zOffset;
+    //instead of keeping those variables, equivalent information can probably be recovered from minX, minY, minZ (which are 1/8th of a block aligned), but possibly with additional floating point error
+
+    public VoxelShapeAlignedCuboid_Offset(VoxelShapeAlignedCuboid originalShape, VoxelSet voxels, double xOffset, double yOffset, double zOffset) {
+        super(voxels, originalShape.xSegments, originalShape.ySegments, originalShape.zSegments,
+                originalShape.minX + xOffset, originalShape.minY + yOffset, originalShape.minZ + zOffset,
+                originalShape.maxX + xOffset, originalShape.maxY + yOffset, originalShape.maxZ + zOffset);
+
+        if (originalShape instanceof VoxelShapeAlignedCuboid_Offset) {
+            this.xOffset = ((VoxelShapeAlignedCuboid_Offset) originalShape).xOffset + xOffset;
+            this.yOffset = ((VoxelShapeAlignedCuboid_Offset) originalShape).yOffset + yOffset;
+            this.zOffset = ((VoxelShapeAlignedCuboid_Offset) originalShape).zOffset + zOffset;
+        } else {
+            this.xOffset = xOffset;
+            this.yOffset = yOffset;
+            this.zOffset = zOffset;
+        }
+    }
+
+    @Override
+    public VoxelShape offset(double x, double y, double z) {
+        return new VoxelShapeAlignedCuboid_Offset(this, this.voxels, x, y, z);
+    }
+
+    @Override
+    public double calculateMaxDistance(AxisCycleDirection cycleDirection, Box box, double maxDist) {
+        if (Math.abs(maxDist) < EPSILON) {
+            return 0.0D;
+        }
+
+        double penetration = this.calculatePenetration(cycleDirection, box, maxDist);
+
+        if ((penetration != maxDist) && this.intersects(cycleDirection, box)) {
+            return penetration;
+        }
+
+        return maxDist;
+    }
+
+    private double calculatePenetration(AxisCycleDirection dir, Box box, double maxDist) {
+        switch (dir) {
+            case NONE:
+                return VoxelShapeAlignedCuboid_Offset.calculatePenetration(this.minX, this.maxX, this.xSegments, this.xOffset, box.minX, box.maxX, maxDist);
+            case FORWARD:
+                return VoxelShapeAlignedCuboid_Offset.calculatePenetration(this.minZ, this.maxZ, this.zSegments, this.zOffset, box.minZ, box.maxZ, maxDist);
+            case BACKWARD:
+                return VoxelShapeAlignedCuboid_Offset.calculatePenetration(this.minY, this.maxY, this.ySegments, this.yOffset, box.minY, box.maxY, maxDist);
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+
+    /**
+     * Determine how far the movement is possible.
+     */
+    private static double calculatePenetration(double aMin, double aMax, final int segmentsPerUnit, double shapeOffset, double bMin, double bMax, double maxDist) {
+        double gap;
+
+        if (maxDist > 0.0D) {
+            gap = aMin - bMax;
+
+            if (gap >= -EPSILON) {
+                //outside the shape/within margin, move up to/back to boundary
+                return Math.min(gap, maxDist);
+            } else {
+                //already far enough inside this shape to not collide with the surface
+                if (segmentsPerUnit == 1) {
+                    //no extra segments to collide with, because only one segment in total
+                    return maxDist;
+                }
+                //extra segment walls / hitboxes inside this shape, evenly spaced out in 0..1 + shapeOffset
+                //round to the next segment wall, but with epsilon margin like vanilla
+
+                //using large epsilon and extra check here because +- shapeOffset can cause larger floating point errors
+                int segment = MathHelper.ceil((bMax - LARGE_EPSILON - shapeOffset) * segmentsPerUnit);
+                double wallPos = segment / (double) segmentsPerUnit + shapeOffset;
+                if (wallPos < bMax - EPSILON) {
+                    ++segment;
+                    wallPos = segment / (double) segmentsPerUnit + shapeOffset;
+                }
+                //only use the wall when it is actually inside the shape, and not a border / outside the shape
+                if (wallPos < aMax - LARGE_EPSILON)
+                    return Math.min(maxDist, wallPos - bMax);
+                return maxDist;
+            }
+        } else {
+            //whole code again, just negated for the other direction
+            gap = aMax - bMin;
+
+            if (gap <= EPSILON) {
+                //outside the shape/within margin, move up to/back to boundary
+                return Math.max(gap, maxDist);
+            } else {
+                //already far enough inside this shape to not collide with the surface
+                if (segmentsPerUnit == 1) {
+                    //no extra segments to collide with, because only one segment in total
+                    return maxDist;
+                }
+                //extra segment walls / hitboxes inside this shape, evenly spaced out in 0..1
+                //round to the next segment wall, but with epsilon margin like vanilla
+
+                //using large epsilon and extra check here because +- shapeOffset can cause larger floating point errors
+                int segment = MathHelper.floor((bMin + LARGE_EPSILON - shapeOffset) * segmentsPerUnit);
+                double wallPos = segment / (double) segmentsPerUnit + shapeOffset;
+                if (wallPos > bMin + EPSILON) {
+                    --segment;
+                    wallPos = segment / (double) segmentsPerUnit + shapeOffset;
+                }
+                //only use the wall when it is actually inside the shape, and not a border / outside the shape
+                if (wallPos > aMin + LARGE_EPSILON)
+                    return Math.max(maxDist, wallPos - bMin);
+                return maxDist;
+            }
+        }
+    }
+}

--- a/src/main/resources/lithium.accesswidener
+++ b/src/main/resources/lithium.accesswidener
@@ -26,3 +26,5 @@ accessible field net/minecraft/util/math/noise/SimplexNoiseSampler gradients [[I
 accessible class net/minecraft/server/world/ChunkTicketManager$TicketDistanceLevelPropagator
 accessible method net/minecraft/world/ChunkPosDistanceLevelPropagator updateLevel (JIZ)V
 accessible method net/minecraft/server/world/ChunkTicket isExpired (J)Z
+
+accessible method net/minecraft/util/shape/VoxelShapes findRequiredBitResolution (DD)I

--- a/src/test/java/net/minecraft/util/shape/TestCustomVoxelShapesCollisions.java
+++ b/src/test/java/net/minecraft/util/shape/TestCustomVoxelShapesCollisions.java
@@ -1,0 +1,144 @@
+package net.minecraft.util.shape;
+
+import me.jellysquid.mods.lithium.common.shapes.VoxelShapeAlignedCuboid;
+import me.jellysquid.mods.lithium.common.shapes.VoxelShapeAlignedCuboid_Offset;
+import me.jellysquid.mods.lithium.mixin.shapes.specialized_shapes.VoxelShapesMixin;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.Direction;
+//import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+/**
+ * Test for the specialized shapes / custom voxel shape implementation.
+ * This test compares the collision behavior of VoxelShapes using randomized boxes and randomized movements.
+ * As 1/8 block aligned shapes, deviations by ~1e-7 and offset shapes are handled specially in vanilla code,
+ * we attempt to also include those cases in the test.
+ * The test prints its random seed when it fails, so failures are reproducible in the debugger.
+ *
+ * @author 2No2Name
+ */
+public class TestCustomVoxelShapesCollisions {
+    public static void main(String[] args) {
+        new TestCustomVoxelShapesCollisions().testCollisions();
+        System.out.println("VoxelShape collision test passed.");
+    }
+
+    public static Direction.Axis[] AXES = Direction.Axis.values();
+
+    public long noCollision;
+    public long collision;
+    public long intersects;
+    public long intersectsCollision;
+    public long withCollisionBoxesInside;
+    public long randomSeed;
+
+
+    public Random rand;
+    public double[] distances;
+    private Box[] boxes;
+
+//    @Test
+    public void testCollisions() {
+        this.noCollision = 0;
+        this.collision = 0;
+        this.intersects = 0;
+        this.intersectsCollision = 0;
+        this.withCollisionBoxesInside = 0;
+
+        this.rand = new Random();
+        //insert your seed here for debugging when the test failed and printed its seed
+        long seed = this.rand.nextLong();
+        this.rand.setSeed(seed);
+        this.randomSeed = seed;
+
+        this.boxes = new Box[20];
+        this.boxes[0] = new Box(0.2931994021407849, 0.5175531777466607, 0.14575020167685837, 1.4562191976519117, 2.2389429614133496, 0.31827209851790766);
+        this.boxes[1] = new Box(0.5 - 0.5E-7, 0.75, 0.125 + 1E-7, 1, 1+1E-6, 0.5);
+        for (int i = 2; i < 20; i++) {
+            this.boxes[i] = getRandomBox(this.rand);
+        }
+
+        Random rand = this.rand;
+        this.distances = new double[]{2.814955055053852, 5 * rand.nextDouble(), -5 * rand.nextDouble(), 5 * rand.nextDouble(), -5 * rand.nextDouble(), 1E-7, 1.1E-7, 0.9E-7, -1E-7, -1.1E-7, -0.9E-7, 1, 10, -1, -10, 0.1, -0.1, 0.25, -0.25, 0.33, -0.33, 1 - 1E-7, -1 + 1E-7, 5 * rand.nextDouble(), -5 * rand.nextDouble(), 5 * rand.nextDouble(), -5 * rand.nextDouble()};
+
+
+        //test all of the 1/8th of a block aligned shapes
+        for (int x = 0; x <= 7; x++) {
+            for(int x2 = x + 1; x2 <= 8; x2++) {
+                for (int y = 0; y <= 7; y++) {
+                    for(int y2 = y + 1; y2 <= 8; y2++) {
+                        for (int z = 0; z <= 7; z++) {
+                            for(int z2 = z + 1; z2 <= 8; z2++) {
+                                VoxelShape[] pair = getVanillaModdedVoxelShapePair(new Box(x/8D,y/8D,z/8D,x2/8D,y2/8D,z2/8D));
+                                this.testShapeBehaviorEquality(pair);
+                                //test random offsetting to test VoxelShapeAlignedCuboid_Offset
+                                double xOff = 5* rand.nextGaussian();
+                                double yOff = 4* rand.nextDouble();
+                                double zOff = rand.nextDouble();
+                                pair[0] = pair[0].offset(xOff, yOff, zOff);
+                                pair[1] = pair[1].offset(xOff, yOff, zOff);
+                                this.testShapeBehaviorEquality(pair);
+                                //test random EPSILON-sized deviations
+                                pair = getVanillaModdedVoxelShapePair(new Box(x/8D + 2E-7*this.rand.nextDouble(),y/8D + 4E-8,z/8D,x2/8D,y2/8D+9E-8,z2/8D));
+                                this.testShapeBehaviorEquality(pair);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        //test some random shapes, just in case there is a really stupid mistake somewhere
+        for (int i = 0; i < 2000; i++) {
+            this.testShapeBehaviorEquality(getVanillaModdedVoxelShapePair(new Box(rand.nextGaussian(), rand.nextGaussian(), rand.nextGaussian(), rand.nextGaussian(), rand.nextGaussian(), rand.nextGaussian())));
+        }
+    }
+
+    public static Box getRandomBox(Random random) {
+        double x1 = random.nextDouble() * 2;
+        double y1 = random.nextDouble() * 2;
+        double z1 = random.nextDouble() * 2;
+        return new Box(x1, y1, z1, 2*x1 + random.nextGaussian(), 2*y1 + random.nextGaussian(), 2*z1 * random.nextGaussian());
+    }
+
+    public void testShapeBehaviorEquality(VoxelShape[] pair) {
+        for (Direction.Axis axis : AXES) {
+            for (double maxDist : distances) {
+                for (Box box : boxes) {
+                    double resultVanilla = pair[0].calculateMaxDistance(axis, box, maxDist);
+                    double resultModded = pair[1].calculateMaxDistance(axis, box, maxDist);
+                    int collided = 0;
+                    if (resultVanilla == maxDist) {
+                        noCollision++;
+                    } else {
+                        collision++;
+                        collided = 1;
+                    }
+                    if (pair[0].getBoundingBox().intersects(box)) {
+                        intersects++;
+                        intersectsCollision += collided;
+                    }
+                    if (pair[1] instanceof VoxelShapeAlignedCuboid) {
+                        withCollisionBoxesInside++;
+                    }
+
+                    if (resultModded != resultVanilla) {
+//these lines only make debugging easier
+//                        boolean repeat = true;
+//                        while(repeat) {
+//                            double resultVanilla2 = pair[0].calculateMaxDistance(axis, box, maxDist);
+//                            double resultModded2 = pair[1].calculateMaxDistance(axis, box, maxDist);
+//                            if (resultVanilla != resultVanilla2)
+//                                repeat = false;
+//                        }
+                        throw new IllegalStateException(String.format("RNG seed: %s, different results for: %s, %s in calculateMaxDistance with arguments axis: %s, box: %s, maxDist: %s, result vanilla: %s, result modded: %s", randomSeed, pair[0], pair[1], axis, box, maxDist, resultVanilla, resultModded));
+                    }
+                }
+            }
+        }
+    }
+
+    public static VoxelShape[] getVanillaModdedVoxelShapePair(Box box) {
+        return new VoxelShape[]{VoxelShapes.cuboid(box), VoxelShapesMixin.cuboid(box)};
+    }
+}


### PR DESCRIPTION
This PR adds collision boxes inside some blocks (e.g. extended piston base, daylight sensors) as they are in vanilla.
This fixes: Lithium removes hitboxes inside some blocks. #60 

The bug was caused by lithium not implementing the weird behavior from vanilla, where SimpleVoxelShapes with BitSetVoxelSets behave as if they have a hitbox at every 1/8th or 1/4th of a block inside them.

The problem is solved by adding a new VoxelShapeCuboidWithCollisionBoxesInside extends VoxelShapeSimpleCube that mimicks the behavior from vanilla. The overwritten VoxelShapes.cuboid(Box box) method now decides whether a VoxelShapeSimpleCube can be used or the more complex VoxelShapeCuboidWithCollisionBoxesInside needs to be used, by testing whether vanilla would create a shape with extra hitboxes inside. This probably costs some runtime, so benchmarks need to be done.