### PR TITLE
new: Include complete entity listener description in IllegalStateException message

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/entity/tracker/EntityTrackerEngine.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/entity/tracker/EntityTrackerEngine.java
@@ -108,7 +108,7 @@ public class EntityTrackerEngine {
                 list.removeListener(listener);
             }
         } else {
-            throw new IllegalArgumentException("Entity listener not tracked");
+            throw new IllegalArgumentException("Entity listener not tracked:" + listener.toString());
         }
     }
 

--- a/src/main/java/me/jellysquid/mods/lithium/common/entity/tracker/nearby/NearbyEntityListenerMulti.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/entity/tracker/nearby/NearbyEntityListenerMulti.java
@@ -45,4 +45,15 @@ public class NearbyEntityListenerMulti implements NearbyEntityListener {
         }
     }
 
+    @Override
+    public String toString() {
+        StringBuilder sublisteners = new StringBuilder();
+        String comma = "";
+        for (NearbyEntityListener listener : listeners) {
+            sublisteners.append(comma).append(listener.toString());
+            comma = ","; //trick to drop the first comma
+        }
+
+        return super.toString() + " with sublisteners: [" + sublisteners + "]";
+    }
 }

--- a/src/main/java/me/jellysquid/mods/lithium/common/entity/tracker/nearby/NearbyEntityTracker.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/entity/tracker/nearby/NearbyEntityTracker.java
@@ -84,4 +84,9 @@ public class NearbyEntityTracker<T extends LivingEntity> implements NearbyEntity
 
         return null;
     }
+
+    @Override
+    public String toString() {
+        return super.toString() + " for entity class: " + clazz.getName() + ", in rangeSq: " + rangeSq + ", around entity: " + self.toString();
+    }
 }


### PR DESCRIPTION
As there have been several bugreports about crashes with the EntityTrackerEngine trying to remove an entity tracker that wasn't tracked, I suggest adding debug statements to find out more about the entities that the trackers belong to. Later additional info as the full NBT of the entity or a counter (times the entity tracker was added or removed from the entity tracker engine) might be useful for debugging as well. 

This PR adds a more detailed printout to the IllegalStateException in the EntityTrackerEngine. For example (manually created with the debugger): java.lang.IllegalArgumentException: Entity listener not tracked: me.jellysquid.mods.lithium.common.entity.tracker.nearby.NearbyEntityListenerMulti@72940e69 with sublisteners: [me.jellysquid.mods.lithium.common.entity.tracker.nearby.NearbyEntityTracker@3ff91bf7 for entity class: net.minecraft.entity.player.PlayerEntity, in rangeSq: 36.0, around entity: SheepEntity['Sheep'/15, l='ServerLevel[flatworld]', x=143.99, y=1.00, z=-245.12]]
