### PR TITLE
new: use shape cache in collision code

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/shapes/blockstate_use_collision_cache/AbstractBlockStateMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/shapes/blockstate_use_collision_cache/AbstractBlockStateMixin.java
@@ -1,0 +1,46 @@
+package me.jellysquid.mods.lithium.mixin.shapes.blockstate_use_collision_cache;
+
+import net.minecraft.block.*;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(AbstractBlock.AbstractBlockState.class)
+public abstract class AbstractBlockStateMixin {
+    @Shadow
+    public abstract Block getBlock();
+
+    @Shadow
+    protected abstract BlockState asBlockState();
+
+
+    @Shadow
+    public AbstractBlock.AbstractBlockState.ShapeCache shapeCache;
+
+    /**
+     * @author 2No2Name
+     * @reason Use the shapeCache when it is available.
+     */
+    @Overwrite
+    public VoxelShape getCollisionShape(BlockView world, BlockPos pos, ShapeContext context) {
+        //LAVA has the property that its VoxelShape depends on the ShapeContext.
+        //Usually blocks like that are marked as dynamicBounds() and the shapeCache is not initialized.
+        //For some reason this is not the case for LAVA, therefore checking for shapeCache != null is not enough
+        return this.shapeCache != null && this.getBlock() != Blocks.LAVA ?
+                this.shapeCache.collisionShape : this.getBlock().getCollisionShape(this.asBlockState(), world, pos, context);
+    }
+
+    /**
+     * @author 2No2Name
+     * @reason Avoid the additional checks introduced by the overwrite above. this.shapeCache is already known to be null here.
+     */
+    @Redirect(method = "getCollisionShape(Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/util/shape/VoxelShape;", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/AbstractBlock$AbstractBlockState;getCollisionShape(Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/ShapeContext;)Lnet/minecraft/util/shape/VoxelShape;"))
+    public VoxelShape getCollisionShape(AbstractBlock.AbstractBlockState abstractBlockState, BlockView world, BlockPos pos, ShapeContext context) {
+        return this.getBlock().getCollisionShape(this.asBlockState(), world, pos, context);
+    }
+}

--- a/src/main/resources/lithium.accesswidener
+++ b/src/main/resources/lithium.accesswidener
@@ -26,3 +26,6 @@ accessible field net/minecraft/util/math/noise/SimplexNoiseSampler gradients [[I
 accessible class net/minecraft/server/world/ChunkTicketManager$TicketDistanceLevelPropagator
 accessible method net/minecraft/world/ChunkPosDistanceLevelPropagator updateLevel (JIZ)V
 accessible method net/minecraft/server/world/ChunkTicket isExpired (J)Z
+
+accessible field net/minecraft/block/AbstractBlock$AbstractBlockState shapeCache Lnet/minecraft/block/AbstractBlock$AbstractBlockState$ShapeCache;
+accessible field net/minecraft/block/AbstractBlock$AbstractBlockState$ShapeCache collisionShape Lnet/minecraft/util/shape/VoxelShape;

--- a/src/main/resources/lithium.mixins.json
+++ b/src/main/resources/lithium.mixins.json
@@ -77,6 +77,7 @@
         "shapes.blockstate_cache.AbstractBlockStateMixin",
         "shapes.blockstate_cache.BlockMixin",
         "shapes.blockstate_cache.BlockShapeCacheMixin",
+        "shapes.blockstate_use_collision_cache.AbstractBlockStateMixin",
         "shapes.precompute_shape_arrays.SimpleVoxelShapeMixin",
         "shapes.shape_merging.VoxelShapesMixin",
         "shapes.specialized_shapes.VoxelShapeMixin",


### PR DESCRIPTION
This PR speeds up getting VoxelShapes from blocks by using the shapeCache of the blocks. Without any good reason vanilla wasn't using the shapeCache in all places.

Due to an inconsistency in vanilla code (LAVA not marked as dynamicBounds() but still changing depending on the ShapeContext (Strider entity)) an additional check for LAVA is required. There are no other blocks with that behavior.