### PR TITLE
Speed up locating structures greatly

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/gen/features/StructureFeatureMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/gen/features/StructureFeatureMixin.java
@@ -34,7 +34,7 @@ public class StructureFeatureMixin {
                     to = @At(value = "INVOKE", target = "Lnet/minecraft/world/chunk/Chunk;getPos()Lnet/minecraft/util/math/ChunkPos;", ordinal = 0)))
     private Chunk biomeConditionalGetChunk(WorldView worldView, int x, int z, ChunkStatus status)
     {
-        if (worldView.getBiomeAccess().getBiomeForNoiseGen(x << 2, 60, z << 2).hasStructureFeature((StructureFeature) (Object) this))
+        if (worldView.getBiomeForNoiseGen((x << 2) + 2, 0, (z << 2) + 2).hasStructureFeature((StructureFeature) (Object) this))
             return worldView.getChunk(x, z, status);
         else
             return null;

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/gen/features/StructureFeatureMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/gen/features/StructureFeatureMixin.java
@@ -42,7 +42,7 @@ public class StructureFeatureMixin {
                         int q = k + j * o;
                         int r = m + j * p;
                         ChunkPos chunkPos = thisStructure.method_27218(structureConfig, l, chunkRandom, q, r);
-                        if(worldView.getBiomeAccess().getBiomeForNoiseGen(chunkPos.x << 2, 60, chunkPos.z << 2).hasStructureFeature(thisStructure)) {
+                        if(worldView.getBiomeForNoiseGen(chunkPos.x << 2, 60, chunkPos.z << 2).hasStructureFeature(thisStructure)) {
                             Chunk chunk = worldView.getChunk(chunkPos.x, chunkPos.z, ChunkStatus.STRUCTURE_STARTS);
                             StructureStart<?> structureStart = structureAccessor.getStructureStart(ChunkSectionPos.from(chunk.getPos(), 0), thisStructure, chunk);
                             if (structureStart != null && structureStart.hasChildren()) {

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/gen/features/StructureFeatureMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/gen/features/StructureFeatureMixin.java
@@ -1,0 +1,74 @@
+package me.jellysquid.mods.lithium.mixin.gen.features;
+
+import net.minecraft.structure.StructureStart;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.ChunkSectionPos;
+import net.minecraft.world.WorldView;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.ChunkStatus;
+import net.minecraft.world.gen.ChunkRandom;
+import net.minecraft.world.gen.StructureAccessor;
+import net.minecraft.world.gen.chunk.StructureConfig;
+import net.minecraft.world.gen.feature.FeatureConfig;
+import net.minecraft.world.gen.feature.StructureFeature;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(StructureFeature.class)
+public class StructureFeatureMixin {
+
+    /**
+     * @reason Why generate an empty chunk to check for a structure if
+     * the chunk's biome cannot generate the structure anyway?
+     * Checking the biome first = SPEED!
+     * @author TelepathicGrunt
+     */
+    @Overwrite
+    public BlockPos locateStructure(WorldView worldView, StructureAccessor structureAccessor, BlockPos blockPos, int i, boolean skipExistingChunks, long l, StructureConfig structureConfig) {
+        int j = structureConfig.getSpacing();
+        int k = blockPos.getX() >> 4;
+        int m = blockPos.getZ() >> 4;
+        int n = 0;
+        StructureFeature thisStructure = ((StructureFeature) (Object) this);
+
+        for(ChunkRandom chunkRandom = new ChunkRandom(); n <= i; ++n) {
+            for(int o = -n; o <= n; ++o) {
+                boolean bl = o == -n || o == n;
+
+                for(int p = -n; p <= n; ++p) {
+                    boolean bl2 = p == -n || p == n;
+                    if (bl || bl2) {
+                        int q = k + j * o;
+                        int r = m + j * p;
+                        ChunkPos chunkPos = thisStructure.method_27218(structureConfig, l, chunkRandom, q, r);
+                        if(worldView.getBiomeAccess().getBiomeForNoiseGen(chunkPos.x << 2, 60, chunkPos.z << 2).hasStructureFeature(thisStructure)) {
+                            Chunk chunk = worldView.getChunk(chunkPos.x, chunkPos.z, ChunkStatus.STRUCTURE_STARTS);
+                            StructureStart<?> structureStart = structureAccessor.getStructureStart(ChunkSectionPos.from(chunk.getPos(), 0), thisStructure, chunk);
+                            if (structureStart != null && structureStart.hasChildren()) {
+                                if (skipExistingChunks && structureStart.isInExistingChunk()) {
+                                    structureStart.incrementReferences();
+                                    return structureStart.getPos();
+                                }
+
+                                if (!skipExistingChunks) {
+                                    return structureStart.getPos();
+                                }
+                            }
+                        }
+
+                        if (n == 0) {
+                            break;
+                        }
+                    }
+                }
+
+                if (n == 0) {
+                    break;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/resources/lithium.mixins.json
+++ b/src/main/resources/lithium.mixins.json
@@ -68,6 +68,7 @@
         "gen.fast_layer_sampling.ScaleLayerMixin",
         "gen.fast_multi_source_biomes.MultiNoiseBiomeSourceMixin",
         "gen.fast_noise_interpolation.SurfaceChunkGeneratorMixin",
+        "gen.features.StructureFeatureMixin",
         "gen.perlin_noise.PerlinNoiseSamplerMixin",
         "gen.voronoi_biomes.VoronoiBiomeAccessTypeMixin",
         "math.fast_util.AxisCycleDirectionMixin$BackwardMixin",


### PR DESCRIPTION
This PR adds a single if statement into StructrueFeature's locateStructure method so that instead of generating empty chunks to check for if the structure can spawn, it checks the biome first which is far faster. 

You can see the speed boost in the videos attached to the issue report here:
https://github.com/jellysquid3/lithium-fabric/issues/85

The main line of code responsible for the significant speed boost
`if(worldView.getBiomeAccess().getBiomeForNoiseGen(chunkPos.x << 2, 60, chunkPos.z << 2).hasStructureFeature(thisStructure)) {`
                
I have tested in both vanilla and with the patch and /locate finds the exact same structure in the same spot so vanilla parity is preserved. I have agreed to the CLA and the relicensing of this piece of code. I hope this helps!

Things that will be greatly benefit from the locating structure speed boost:
-/locate command
-Treasure maps (especially those that skip existing chunks)
-Any modded item, command, mobs, etc that uses locateStructure in backend to find a structure.

The biggest noticeable change in the speed of finding a structure is doing any of the above for a structure that has a spacing of 1, separation of 0, and is added to a very rare far away biome. Doing /locate on that can hang the server for minutes on end while with this patch, will take only a few seconds instead. :)