### PR TITLE
new: cache netherrack blob generation

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/gen/fast_netherrack_replacement_blobs/NetherrackReplaceBlobsFeatureMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/gen/fast_netherrack_replacement_blobs/NetherrackReplaceBlobsFeatureMixin.java
@@ -1,0 +1,120 @@
+package me.jellysquid.mods.lithium.mixin.gen.fast_netherrack_replacement_blobs;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
+import com.google.common.collect.ImmutableList;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec3i;
+import net.minecraft.world.ServerWorldAccess;
+import net.minecraft.world.WorldAccess;
+import net.minecraft.world.gen.StructureAccessor;
+import net.minecraft.world.gen.chunk.ChunkGenerator;
+import net.minecraft.world.gen.feature.NetherrackReplaceBlobsFeature;
+import net.minecraft.world.gen.feature.NetherrackReplaceBlobsFeatureConfig;
+
+@Mixin(NetherrackReplaceBlobsFeature.class)
+public abstract class NetherrackReplaceBlobsFeatureMixin {
+	private static final Long2ObjectOpenHashMap<List<BlockPos>> DELTA_CACHE = new Long2ObjectOpenHashMap<>();
+
+	static {
+		DELTA_CACHE.defaultReturnValue(null);
+	}
+
+	// Finds start position
+	@Shadow
+	protected static BlockPos method_27107(WorldAccess world, BlockPos.Mutable mutable, Block block) {
+		return null;
+	}
+
+	// Generates the size of this blob
+	@Shadow
+	protected static Vec3i method_27108(Random random, NetherrackReplaceBlobsFeatureConfig config) {
+		return null;
+	}
+
+	/**
+	 * @reason Faster implementation which utilizes a cache of delta positions instead of iterating outwards many times.
+     * This saves many CPU cycles as this feature is called 100 times per chunk in the Basalt Deltas biome.
+	 * @author SuperCoder79
+	 */
+	@Overwrite
+	public boolean generate(ServerWorldAccess world, StructureAccessor structureAccessor, ChunkGenerator chunkGenerator, Random random, BlockPos blockPos, NetherrackReplaceBlobsFeatureConfig config) {
+		// [VanillaCopy] NetherrackReplaceBlobsFeature#generate
+
+	    Block targetBlock = config.target.getBlock();
+
+		// Get start position
+		BlockPos startPos = method_27107(world, blockPos.mutableCopy().method_27158(Direction.Axis.Y, 1, world.getHeight() - 1), targetBlock);
+
+		// Exit early if we couldn't create the start position.
+		if (startPos == null) {
+			return false;
+		} else {
+			boolean didPlace = false;
+
+			// Get the delta positions from size vector
+			List<BlockPos> deltas = getDeltas(method_27108(random, config));
+			BlockPos.Mutable mutable = new BlockPos.Mutable();
+
+			// Iterate through the delta positions and attempt to place each one.
+			for (BlockPos delta : deltas) {
+				// Add the delta to the start position
+				mutable.set(startPos, delta.getX(), delta.getY(), delta.getZ());
+
+				// If the block here is the target, replace.
+				BlockState hereState = world.getBlockState(mutable);
+				if (hereState.isOf(targetBlock)) {
+					world.setBlockState(mutable, config.state, 3);
+					didPlace = true;
+				}
+			}
+
+			return didPlace;
+		}
+	}
+
+	private static List<BlockPos> getDeltas(Vec3i size) {
+	    // Attempt to retrieve values from the cache
+		long packed = BlockPos.asLong(size.getX(), size.getY(), size.getZ());
+		List<BlockPos> deltas = DELTA_CACHE.get(packed);
+
+		// Cache hit, return value
+		if (deltas != null) {
+			return deltas;
+		}
+
+		// Cache miss, compute and store
+
+        // Get the largest of the sides
+		int maxExtent = Math.max(size.getX(), Math.max(size.getY(), size.getZ()));
+
+		// Iterate outwards and add the deltas that are within the max extent
+		deltas = new ArrayList<>();
+		for (BlockPos pos : BlockPos.iterateOutwards(BlockPos.ORIGIN, size.getX(), size.getY(), size.getZ())) {
+			BlockPos delta = pos.toImmutable();
+
+			// Only add the positions whose distance from the origin are less than the maxExtent, creating a sphere.
+            // In vanilla, this is run every time the feature generates but we can cache it for a large benefit.
+			if (!(delta.getManhattanDistance(BlockPos.ORIGIN) > maxExtent)) {
+				deltas.add(delta);
+			}
+		}
+
+		// Store values and return
+		DELTA_CACHE.put(packed, deltas);
+
+		return deltas;
+
+	}
+}

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/gen/fast_netherrack_replacement_blobs/NetherrackReplaceBlobsFeatureMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/gen/fast_netherrack_replacement_blobs/NetherrackReplaceBlobsFeatureMixin.java
@@ -1,19 +1,13 @@
 package me.jellysquid.mods.lithium.mixin.gen.fast_netherrack_replacement_blobs;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-
-import it.unimi.dsi.fastutil.longs.Long2ReferenceLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.HashCommon;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.Shadow;
-
+import it.unimi.dsi.fastutil.longs.LongList;
+import it.unimi.dsi.fastutil.longs.LongListIterator;
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3i;
 import net.minecraft.world.ServerWorldAccess;
 import net.minecraft.world.WorldAccess;
@@ -21,105 +15,131 @@ import net.minecraft.world.gen.StructureAccessor;
 import net.minecraft.world.gen.chunk.ChunkGenerator;
 import net.minecraft.world.gen.feature.NetherrackReplaceBlobsFeature;
 import net.minecraft.world.gen.feature.NetherrackReplaceBlobsFeatureConfig;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.Random;
 
 @Mixin(NetherrackReplaceBlobsFeature.class)
 public abstract class NetherrackReplaceBlobsFeatureMixin {
-	private static final Long2ReferenceLinkedOpenHashMap<LongArrayList> DELTA_CACHE = new Long2ReferenceLinkedOpenHashMap<>();
+    private static final Cache SHAPE_CACHE = new Cache(128);
 
-	static {
-		DELTA_CACHE.defaultReturnValue(null);
-	}
+    // Finds start position
+    @Shadow
+    private static BlockPos method_27107(WorldAccess world, BlockPos.Mutable mutable, Block block) {
+        throw new UnsupportedOperationException();
+    }
 
-	// Finds start position
-	@Shadow
-	protected static BlockPos method_27107(WorldAccess world, BlockPos.Mutable mutable, Block block) {
-		return null;
-	}
+    // Generates the size of this blob
+    @Shadow
+    private static Vec3i method_27108(Random random, NetherrackReplaceBlobsFeatureConfig config) {
+        throw new UnsupportedOperationException();
+    }
 
-	// Generates the size of this blob
-	@Shadow
-	protected static Vec3i method_27108(Random random, NetherrackReplaceBlobsFeatureConfig config) {
-		return null;
-	}
-
-	/**
-	 * @reason Faster implementation which utilizes a cache of delta positions instead of iterating outwards many times.
+    /**
+     * @reason Faster implementation which utilizes a cache of delta positions instead of iterating outwards many times.
      * This saves many CPU cycles as this feature is called 100 times per chunk in the Basalt Deltas biome.
-	 * @author SuperCoder79
-	 */
-	@Overwrite
-	public boolean generate(ServerWorldAccess world, StructureAccessor structureAccessor, ChunkGenerator chunkGenerator, Random random, BlockPos blockPos, NetherrackReplaceBlobsFeatureConfig config) {
-		// [VanillaCopy] NetherrackReplaceBlobsFeature#generate
+     * @author SuperCoder79
+     */
+    @Overwrite
+    public boolean generate(ServerWorldAccess world, StructureAccessor structures, ChunkGenerator generator, Random random, BlockPos origin, NetherrackReplaceBlobsFeatureConfig config) {
+        // [VanillaCopy] NetherrackReplaceBlobsFeature#generate
 
-	    Block targetBlock = config.target.getBlock();
+        Block targetBlock = config.target.getBlock();
 
-		// Get start position
-		BlockPos startPos = method_27107(world, blockPos.mutableCopy().method_27158(Direction.Axis.Y, 1, world.getHeight() - 1), targetBlock);
+        // Get start position
+        BlockPos startPos = method_27107(world, origin.mutableCopy().method_27158(Direction.Axis.Y, 1, world.getHeight() - 1), targetBlock);
 
-		// Exit early if we couldn't create the start position.
-		if (startPos == null) {
-			return false;
-		} else {
-			boolean didPlace = false;
-
-			// Get the delta positions from size vector
-            LongArrayList deltas = getDeltas(method_27108(random, config));
-			BlockPos.Mutable mutable = new BlockPos.Mutable();
-
-			// Iterate through the delta positions and attempt to place each one.
-			for (long delta : deltas) {
-				// Add the delta to the start position
-				mutable.set(startPos, BlockPos.unpackLongX(delta), BlockPos.unpackLongY(delta), BlockPos.unpackLongZ(delta));
-
-				// If the block here is the target, replace.
-				BlockState hereState = world.getBlockState(mutable);
-				if (hereState.isOf(targetBlock)) {
-					world.setBlockState(mutable, config.state, 3);
-					didPlace = true;
-				}
-			}
-
-			return didPlace;
-		}
-	}
-
-	private static LongArrayList getDeltas(Vec3i size) {
-	    // Attempt to retrieve values from the cache
-		long packed = BlockPos.asLong(size.getX(), size.getY(), size.getZ());
-        LongArrayList deltas = DELTA_CACHE.get(packed);
-
-		// Cache hit, return value
-		if (deltas != null) {
-			return deltas;
-		}
-
-		// Cache miss, compute and store
-
-        // Get the largest of the sides
-		int maxExtent = Math.max(size.getX(), Math.max(size.getY(), size.getZ()));
-
-		// Iterate outwards and add the deltas that are within the max extent
-		deltas = new LongArrayList();
-		for (BlockPos pos : BlockPos.iterateOutwards(BlockPos.ORIGIN, size.getX(), size.getY(), size.getZ())) {
-			BlockPos delta = pos.toImmutable();
-
-			// Only add the positions whose distance from the origin are less than the maxExtent, creating a sphere.
-            // In vanilla, this is run every time the feature generates but we can cache it for a large benefit.
-			if (!(delta.getManhattanDistance(BlockPos.ORIGIN) > maxExtent)) {
-				deltas.add(delta.asLong());
-			}
-		}
-
-		// Store values and return
-		DELTA_CACHE.put(packed, deltas);
-
-		// Ensure that the cache doesn't overflow by removing entries after a certain threshold.
-        // In this case, the chosen threshold is 125 as vanilla only creates blobs that have a size from 3-7 on all axes.
-		if (DELTA_CACHE.size() > 125) {
-		    DELTA_CACHE.removeLast();
+        // Exit early if we couldn't create the start position.
+        if (startPos == null) {
+            return false;
         }
 
-		return deltas;
+        // Get the delta positions from size vector
+        Vec3i size = method_27108(random, config);
+        LongList shape = SHAPE_CACHE.getOrCompute(size);
 
-	}
+        BlockPos.Mutable mutable = new BlockPos.Mutable();
+
+        boolean didPlace = false;
+
+        // Iterate through the delta positions and attempt to place each one.
+        LongListIterator iterator = shape.iterator();
+
+        // the first value is the size key: skip it
+        iterator.nextLong();
+
+        while (iterator.hasNext()) {
+            long offset = iterator.nextLong();
+
+            // Add the delta to the start position
+            mutable.set(startPos, BlockPos.unpackLongX(offset), BlockPos.unpackLongY(offset), BlockPos.unpackLongZ(offset));
+
+            // If the block here is the target, replace.
+            if (world.getBlockState(mutable).isOf(targetBlock)) {
+                world.setBlockState(mutable, config.state, 3);
+                didPlace = true;
+            }
+        }
+
+        return didPlace;
+    }
+
+    @SuppressWarnings("MixinInnerClass")
+    private static class Cache {
+        private final LongList[] table;
+        private final int mask;
+
+        Cache(int capacity) {
+            capacity = MathHelper.smallestEncompassingPowerOfTwo(capacity);
+            this.mask = capacity - 1;
+
+            this.table = new LongList[capacity];
+        }
+
+        void addPositionsTo(Vec3i size, LongList entry) {
+            // Get the largest of the sides
+            int maxExtent = Math.max(size.getX(), Math.max(size.getY(), size.getZ()));
+
+            // Iterate outwards and add the deltas that are within the max extent
+            for (BlockPos pos : BlockPos.iterateOutwards(BlockPos.ORIGIN, size.getX(), size.getY(), size.getZ())) {
+                // Only add the positions whose distance from the origin are less than the maxExtent, creating a sphere.
+                // In vanilla, this is run every time the feature generates but we can cache it for a large benefit.
+                if (pos.getManhattanDistance(BlockPos.ORIGIN) > maxExtent) {
+                    break;
+                }
+
+                entry.add(pos.asLong());
+            }
+        }
+
+        LongList getOrCompute(Vec3i size) {
+            long key = BlockPos.asLong(size.getX(), size.getY(), size.getZ());
+            int idx = hash(key) & this.mask;
+
+            LongList entry = this.table[idx];
+            if (entry != null && entry.getLong(0) == key) {
+                // cache hit: first value in entry matches our key
+                return entry;
+            }
+
+            // cache miss: compute and store
+            entry = new LongArrayList(16);
+
+            // first value in the entry is the key
+            // we do this to avoid race conditions by having two separate arrays for the keys and values
+            entry.add(key);
+
+            this.addPositionsTo(size, entry);
+
+            this.table[idx] = entry;
+
+            return entry;
+        }
+
+        private static int hash(long key) {
+            return (int) HashCommon.mix(key);
+        }
+    }
 }

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/gen/fast_netherrack_replacement_blobs/NetherrackReplaceBlobsFeatureMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/gen/fast_netherrack_replacement_blobs/NetherrackReplaceBlobsFeatureMixin.java
@@ -67,7 +67,7 @@ public abstract class NetherrackReplaceBlobsFeatureMixin {
         // Iterate through the delta positions and attempt to place each one.
         LongListIterator iterator = shape.iterator();
 
-        // the first value is the size key: skip it
+        // The first value is the size key, so we skip it.
         iterator.nextLong();
 
         while (iterator.hasNext()) {
@@ -120,15 +120,15 @@ public abstract class NetherrackReplaceBlobsFeatureMixin {
 
             LongList entry = this.table[idx];
             if (entry != null && entry.getLong(0) == key) {
-                // cache hit: first value in entry matches our key
+                // Cache hit: first value in entry matches our key
                 return entry;
             }
 
-            // cache miss: compute and store
+            // Cache miss: compute and store
             entry = new LongArrayList(128);
 
-            // first value in the entry is the key
-            // we do this to avoid race conditions by having two separate arrays for the keys and values
+            // First value in the entry is the key.
+            // We do this to avoid race conditions by having two separate arrays for the keys and values.
             entry.add(key);
 
             this.addPositionsTo(size, entry);

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/gen/fast_netherrack_replacement_blobs/NetherrackReplaceBlobsFeatureMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/gen/fast_netherrack_replacement_blobs/NetherrackReplaceBlobsFeatureMixin.java
@@ -125,7 +125,7 @@ public abstract class NetherrackReplaceBlobsFeatureMixin {
             }
 
             // cache miss: compute and store
-            entry = new LongArrayList(16);
+            entry = new LongArrayList(128);
 
             // first value in the entry is the key
             // we do this to avoid race conditions by having two separate arrays for the keys and values

--- a/src/main/resources/lithium.mixins.json
+++ b/src/main/resources/lithium.mixins.json
@@ -67,6 +67,7 @@
         "gen.fast_layer_sampling.CachingLayerContextMixin",
         "gen.fast_layer_sampling.ScaleLayerMixin",
         "gen.fast_multi_source_biomes.MultiNoiseBiomeSourceMixin",
+        "gen.fast_netherrack_replacement_blobs.NetherrackReplaceBlobsFeatureMixin",
         "gen.fast_noise_interpolation.SurfaceChunkGeneratorMixin",
         "gen.perlin_noise.PerlinNoiseSamplerMixin",
         "gen.voronoi_biomes.VoronoiBiomeAccessTypeMixin",


### PR DESCRIPTION
In the nether, the Basalt Deltas biome generates blobs of Basalt and Blackstone to replace netherrack. These blobs iterate outwards from a point and replace the surrounding netherrack in a sphere. However, the sphere is calculated every time the feature generates, which is *100 times per chunk* leading to slowdowns. The fix here is to cache the delta positions of the blob and then reuse it, meaning once a blob of a certain size has been generated, the rest of the blobs can reuse those positions in the future, leading to an immense **83x speedup.**

These times were taken over a period of 3 minutes when the server was constantly generating chunks at the max spectator mode speeds with a mod that set Basalt Deltas to the only biome in the nether.
Before the optimization, 10% of the *total cpu time* was spent on the NetherrackReplaceBlobsFeature:
![image](https://cdn.discordapp.com/attachments/602805971391217683/737380549231902720/unknown.png)
After the optimization, that number was reduced to 0.12%:
![image](https://cdn.discordapp.com/attachments/602805971391217683/737380654513127465/unknown.png)

This change shouldn't change worldgen more than the existing variation between seeds that exists because of the chunk generation order.

I'd also like to thank @gegy1000 for her help with this optimization :D 