### PR TITLE
Make minor optimizations to Piglin group aggro

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/entity/fast_piglin_brain/PiglinBrainMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/entity/fast_piglin_brain/PiglinBrainMixin.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/entity/fast_piglin_brain/PiglinBrainMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/entity/fast_piglin_brain/PiglinBrainMixin.java
@@ -21,7 +21,7 @@ import net.minecraft.world.GameRules;
 public class PiglinBrainMixin {
 
     /**
-     * The vanilla implimentation here seems to be heavy usage of
+     * The vanilla implementation here seems to be heavy usage of
      * functional style java and similar which performs poorly when
      * used in hot code
      * 

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/entity/fast_piglin_brain/PiglinBrainMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/entity/fast_piglin_brain/PiglinBrainMixin.java
@@ -6,6 +6,9 @@ import java.util.Optional;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.At;
 
 import net.minecraft.entity.mob.PiglinBrain;
 import net.minecraft.entity.mob.PiglinEntity;
@@ -17,30 +20,52 @@ import net.minecraft.world.GameRules;
 
 @Mixin(PiglinBrain.class)
 public class PiglinBrainMixin {
-    @Overwrite
-    public static void onGuardedBlockBroken(PlayerEntity player, boolean isInventory) {
-        List<PiglinEntity> list = player.world.getNonSpectatingEntities(PiglinEntity.class, player.getBoundingBox().expand(16.0D));
 
+    /**
+     * The vanilla implimentation here seems to be heavy usage of
+     * functional style java and similar which performs poorly when
+     * used in hot code
+     * 
+     * This optimization here helps to reduce a spike in lag from 
+     * breaking a specific block when near a bunch of piglins
+     * 
+     * @param player the player that broke the block
+     * @param isInventory if the player broke a block that stores items 
+     */
+    @Inject(method = "onGuardedBlockBroken", at = @At("HEAD"), cancellable = true)
+    public static void onGuardedBlockBroken(PlayerEntity player, boolean isInventory, CallbackInfo ci) {
+        List<PiglinEntity> list = player.world.getNonSpectatingEntities(PiglinEntity.class, player.getBoundingBox().expand(16.0D));
         PlayerEntity target;
+
         for(PiglinEntity current : list) {
             if(current.getBrain().hasActivity(Activity.IDLE) && !isInventory && LookTargetUtil.isVisibleInMemory(current, player)) {
                 target = current.world.getGameRules().getBoolean(GameRules.UNIVERSAL_ANGER) ? getNearestDetectedPlayer(current).get() : player;
                 becomeAngryWith(current, target);
             }
         }
+
+        ci.cancel();
     }
 
-    @Overwrite
-    public static void angerNearbyPiglins(PiglinEntity piglin) {
+    /**
+     * This is quite similar to the first method but would be
+     * called quite a bit more often than the other with calls at
+     * least every single time a player attacks a piglin
+     * @param piglin
+     */
+    @Inject(method = "angerNearbyPiglins", at = @At("HEAD"), cancellable = true)
+    public static void angerNearbyPiglins(PiglinEntity piglin, CallbackInfo ci) {
         List<PiglinEntity> nearPiglins = getNearbyPiglins(piglin);
-
         Optional<PlayerEntity> player;
+
         for(PiglinEntity current : nearPiglins) {
             player = getNearestDetectedPlayer(current);
             if(player.isPresent()) {
                 becomeAngryWith(current, player.get());
             }
         }
+
+        ci.cancel();
     }
 
     @Shadow

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/entity/fast_piglin_brain/PiglinBrainMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/entity/fast_piglin_brain/PiglinBrainMixin.java
@@ -1,0 +1,64 @@
+package me.jellysquid.mods.lithium.mixin.entity.fast_piglin_brain;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.entity.mob.PiglinBrain;
+import net.minecraft.entity.mob.PiglinEntity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.ai.brain.Activity;
+import net.minecraft.entity.ai.brain.task.LookTargetUtil;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.world.GameRules;
+
+@Mixin(PiglinBrain.class)
+public class PiglinBrainMixin {
+    @Overwrite
+    public static void onGuardedBlockBroken(PlayerEntity player, boolean isInventory) {
+        List<PiglinEntity> list = player.world.getNonSpectatingEntities(PiglinEntity.class, player.getBoundingBox().expand(16.0D));
+
+        PlayerEntity target;
+        for(PiglinEntity current : list) {
+            if(current.getBrain().hasActivity(Activity.IDLE) && !isInventory && LookTargetUtil.isVisibleInMemory(current, player)) {
+                target = current.world.getGameRules().getBoolean(GameRules.UNIVERSAL_ANGER) ? getNearestDetectedPlayer(current).get() : player;
+                becomeAngryWith(current, target);
+            }
+        }
+    }
+
+    @Overwrite
+    public static void angerNearbyPiglins(PiglinEntity piglin) {
+        List<PiglinEntity> nearPiglins = getNearbyPiglins(piglin);
+
+        Optional<PlayerEntity> player;
+        for(PiglinEntity current : nearPiglins) {
+            player = getNearestDetectedPlayer(current);
+            if(player.isPresent()) {
+                becomeAngryWith(current, player.get());
+            }
+        }
+    }
+
+    @Shadow
+    private static List<PiglinEntity> getNearbyPiglins(PiglinEntity piglin) {
+        return null;
+    }
+
+    @Shadow
+    private static Optional<PlayerEntity> getNearestDetectedPlayer(PiglinEntity current) {
+        return null;
+    }
+
+    @Shadow
+    protected static void becomeAngryWith(PiglinEntity piglin, LivingEntity target) {
+    }
+
+    @Shadow
+    protected static boolean hasIdleActivity(PiglinEntity piglin) {
+        return true;
+    }
+}

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/entity/fast_piglin_brain/PiglinBrainMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/entity/fast_piglin_brain/PiglinBrainMixin.java
@@ -32,7 +32,7 @@ public class PiglinBrainMixin {
      * @param isInventory if the player broke a block that stores items 
      */
     @Inject(method = "onGuardedBlockBroken", at = @At("HEAD"), cancellable = true)
-    public static void onGuardedBlockBroken(PlayerEntity player, boolean isInventory, CallbackInfo ci) {
+    private static void onGuardedBlockBroken(PlayerEntity player, boolean isInventory, CallbackInfo ci) {
         List<PiglinEntity> list = player.world.getNonSpectatingEntities(PiglinEntity.class, player.getBoundingBox().expand(16.0D));
         PlayerEntity target;
 
@@ -53,7 +53,7 @@ public class PiglinBrainMixin {
      * @param piglin
      */
     @Inject(method = "angerNearbyPiglins", at = @At("HEAD"), cancellable = true)
-    public static void angerNearbyPiglins(PiglinEntity piglin, CallbackInfo ci) {
+    private static void angerNearbyPiglins(PiglinEntity piglin, CallbackInfo ci) {
         List<PiglinEntity> nearPiglins = getNearbyPiglins(piglin);
         Optional<PlayerEntity> player;
 

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/entity/fast_piglin_brain/PiglinSpecificSensorMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/entity/fast_piglin_brain/PiglinSpecificSensorMixin.java
@@ -18,6 +18,7 @@ import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.mob.PiglinBrain;
 import net.minecraft.entity.mob.PiglinEntity;
 import net.minecraft.entity.mob.WitherSkeletonEntity;
+import net.minecraft.entity.mob.ZombifiedPiglinEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.predicate.entity.EntityPredicates;
 import net.minecraft.server.world.ServerWorld;
@@ -30,48 +31,17 @@ import net.minecraft.entity.ai.brain.sensor.PiglinSpecificSensor;
 @Mixin(PiglinSpecificSensor.class)
 public class PiglinSpecificSensorMixin {
 
-    /** A note to maintainers : 
-      * These id's are not safe between versions and most likely will change if a new mob is added,
-      * they are based on the order of entities being added to the ENTITY_TYPE registry
-      * You can check a value by getting the output of Registry.ENTITY_TYPE.get(int) 
-      * There is most likely a better way of doing this specifically however, static finals are inlined
-      * every time they are used and in a loop, inlining a check of a registry numeric id of a string isn't
-      * exactly amazing for performance.
-      * 
-      * If you are updating, check this code to make sure it is the expected entites being returned by those
-      * numeric id's.
-      * 
-      * If a new mob is added to this sensor then its ID should be added here and the accoring code added.
-    */
-    private static final int HOGLIN_ID = 33;
-    private static final int PIGLIN_ID = 60;
-    private static final int PLAYER_ID = 105;
-    private static final int ZOMBIFIED_ID = 104;
-
-
     @Overwrite
     protected void sense(ServerWorld world, LivingEntity entity) {
+        world.getProfiler().push("Piglin Sensing");
+
         Brain<?> brain = entity.getBrain();
         brain.remember(MemoryModuleType.NEAREST_REPELLENT, findSoulFire(world, entity));
-        Optional<MobEntity> nearestVisibleNemisis = Optional.empty();
-        Optional<HoglinEntity> nearestVisibleHuntableHoglin = Optional.empty();
-        Optional<HoglinEntity> nearestVisibleBabyHoglin = Optional.empty();
-        Optional<PiglinEntity> nearestVisibleBabyPiglin = Optional.empty();
-        Optional<LivingEntity> nearestVisibleZombified = Optional.empty();
-        Optional<PlayerEntity> nearPlayerNotInGold = Optional.empty();
-        Optional<PlayerEntity> playerHoldingWantedItem = Optional.empty();
         List<PiglinEntity> visableAdultPiglins = Lists.newArrayList();
         List<PiglinEntity> allAdultPiglins = Lists.newArrayList();
 
         // This list appears to be sorted from nearest to furthest
         List<LivingEntity> allVisibleMobs = (List)brain.getOptionalMemory(MemoryModuleType.VISIBLE_MOBS).orElse(ImmutableList.of());
-        Iterator visibleMobsIterator = allVisibleMobs.iterator();
-
-        Stream players = allVisibleMobs.stream().filter(EntityPredicates.EXCEPT_CREATIVE_SPECTATOR_OR_PEACEFUL);
-        Stream hoglins = allVisibleMobs.stream().filter((currentEntity) -> currentEntity.getEntityId() == HOGLIN_ID);
-        Stream piglins = allVisibleMobs.stream().filter((currentEntity) -> currentEntity.getEntityId() == PIGLIN_ID);
-        
-        brain.remember(MemoryModuleType.NEAREST_VISIBLE_ZOMBIFIED, allVisibleMobs.stream().filter((currentEntity) -> currentEntity.getEntityId()==ZOMBIFIED_ID).findFirst());
 
         int visibleHoglinCount = 0;
         boolean isAdult;
@@ -82,27 +52,16 @@ public class PiglinSpecificSensorMixin {
         boolean foundBabyPiglin = false;
         boolean foundAttackablePlayer = false;
         boolean foundPlayerHoldingGold = false;
+        boolean foundZombifiedPiglin = false;
         boolean foundNemisis = false;
         
         for(LivingEntity currentLivingEntity : allVisibleMobs) {
             // avoid many calls to isBaby() and just inline by hand to make sure
+
             isAdult = !currentLivingEntity.isBaby();
 
-            /**
-             * To my knowledge, switches are faster than multiple if's.
-             * Also checking an int comparison in this case should be quicker than
-             * checking an instanceof, this should also be a bit more optimized for 
-             * the order at which things can be dectected to do early stopping in
-             * the switch statement due to how the fallthrough works.
-             * 
-             * To avoid more allocations, use casting as opposed to more variables
-             * and do so only when necessary
-             */
-            
-            switch(currentLivingEntity.getEntityId()){
-
                 // check if entity is a hoglin
-                case HOGLIN_ID : {
+                if(currentLivingEntity instanceof HoglinEntity)  {
                     if(isAdult) {
                         visibleHoglinCount++;
                         if(!foundHuntableHoglin && ((HoglinEntity)currentLivingEntity).canBeHunted()) {
@@ -114,96 +73,54 @@ public class PiglinSpecificSensorMixin {
                             brain.remember(MemoryModuleType.NEAREST_VISIBLE_BABY_HOGLIN, Optional.of((HoglinEntity)currentLivingEntity));
                         }
                     }
-                    break;
+                    continue;
                 }
 
                 // check if entity is a piglin
-                case PIGLIN_ID : {
+                else if(currentLivingEntity instanceof PiglinEntity) {
                     if(isAdult) {
                         visableAdultPiglins.add((PiglinEntity)currentLivingEntity);
                     } else if(!foundBabyPiglin) {
-                        
+                        brain.remember(MemoryModuleType.NEAREST_VISIBLE_BABY_PIGLIN, Optional.of((PiglinEntity)currentLivingEntity));
                     }
-                }
-            }
-
-            // stop iterating if all required targets were found
-            if(foundAttackablePlayer && foundBabyHoglin && foundBabyPiglin && foundHuntableHoglin && foundNemisis && foundPlayerHoldingGold)
-                return;
-        }
-
-        while(visibleMobsIterator.hasNext()) {
-            LivingEntity currentLivingEntity = (LivingEntity)visibleMobsIterator.next();
-
-            // Check hoglins
-            if (currentLivingEntity instanceof HoglinEntity) {
-                HoglinEntity hoglinEntity = (HoglinEntity)currentLivingEntity;
-                if (!nearestVisibleBabyHoglin.isPresent() && hoglinEntity.isBaby()) {
-                    nearestVisibleBabyHoglin = Optional.of(hoglinEntity);
-                } else if (hoglinEntity.isAdult()) {
-                    ++visibleHoglinCount;
-                    if (!nearestVisibleHuntableHoglin.isPresent() && hoglinEntity.canBeHunted()) {
-                        nearestVisibleHuntableHoglin = Optional.of(hoglinEntity);
-                    }
+                    continue;
                 }
 
-            // check piglins
-            } else if (currentLivingEntity instanceof PiglinEntity) {
-                PiglinEntity piglinEntity = (PiglinEntity)currentLivingEntity;
+                // check if entity is a player
+                else if(currentLivingEntity instanceof PlayerEntity) {
+                    if(!foundAttackablePlayer && EntityPredicates.EXCEPT_CREATIVE_SPECTATOR_OR_PEACEFUL.test(currentLivingEntity) && !PiglinBrain.wearsGoldArmor((PlayerEntity)currentLivingEntity)) {
+                        brain.remember(MemoryModuleType.NEAREST_TARGETABLE_PLAYER_NOT_WEARING_GOLD, (PlayerEntity)currentLivingEntity);
+                        foundAttackablePlayer = true;
+                    } else if(!foundPlayerHoldingGold && !((PlayerEntity)currentLivingEntity).isSpectator() && PiglinBrain.isGoldHoldingPlayer((PlayerEntity)currentLivingEntity)) {
+                        brain.remember(MemoryModuleType.NEAREST_PLAYER_HOLDING_WANTED_ITEM, (PlayerEntity)currentLivingEntity);
+                        foundPlayerHoldingGold = true;
+                    }
+                    continue;
+                }
+
+                // check if entity is Zombified Piglin
+                else if(currentLivingEntity instanceof ZombifiedPiglinEntity) {
+                    if(!foundZombifiedPiglin) {
+                        brain.remember(MemoryModuleType.NEAREST_VISIBLE_ZOMBIFIED, (ZombifiedPiglinEntity)currentLivingEntity);
+                        foundZombifiedPiglin = true;
+                    }
+                }
+
+                // check if entity can be a nemisis
+                else if(currentLivingEntity instanceof WitherEntity || currentLivingEntity instanceof WitherEntity) {
+                    if(!foundNemisis) {
+                        brain.remember(MemoryModuleType.NEAREST_VISIBLE_NEMESIS, (MobEntity)currentLivingEntity);
+                        foundNemisis = true;
+                    }
+                }
                 
-                // check babies
-                if (piglinEntity.isBaby() && !nearestVisibleBabyPiglin.isPresent()) {
-                    nearestVisibleBabyPiglin = Optional.of(piglinEntity);
-                // check adults
-                } else if (piglinEntity.isAdult()) {
-                    visableAdultPiglins.add(piglinEntity);
-                }
-
-            // check players
-            } else if (currentLivingEntity instanceof PlayerEntity) {
-                PlayerEntity playerEntity = (PlayerEntity)currentLivingEntity;
-                //check player thats not in gold
-                if (!nearPlayerNotInGold.isPresent() && EntityPredicates.EXCEPT_CREATIVE_SPECTATOR_OR_PEACEFUL.test(currentLivingEntity) && !PiglinBrain.wearsGoldArmor(playerEntity)) {
-                    nearPlayerNotInGold = Optional.of(playerEntity);
-                }
-
-                // check player holding wanted item
-                if (!playerHoldingWantedItem.isPresent() && !playerEntity.isSpectator() && PiglinBrain.isGoldHoldingPlayer(playerEntity)) {
-                    playerHoldingWantedItem = Optional.of(playerEntity);
-                }
-
-            // check for nemisis
-            } else if (nearestVisibleNemisis.isPresent() || !(currentLivingEntity instanceof WitherSkeletonEntity) && !(currentLivingEntity instanceof WitherEntity)) {
-                if (!nearestVisibleZombified.isPresent() && PiglinBrain.isZombified(currentLivingEntity.getType())) {
-                    nearestVisibleZombified = Optional.of(currentLivingEntity);
-                }
-            } else {
-                nearestVisibleNemisis = Optional.of((MobEntity)currentLivingEntity);
             }
-        }
 
-        List<LivingEntity> mobsMemory = (List)brain.getOptionalMemory(MemoryModuleType.MOBS).orElse(ImmutableList.of());
-        Iterator mobMemoryIterator = mobsMemory.iterator();
-
-        while(mobMemoryIterator.hasNext()) {
-            LivingEntity currentMobInMemory = (LivingEntity)mobMemoryIterator.next();
-            if (currentMobInMemory instanceof PiglinEntity && ((PiglinEntity)currentMobInMemory).isAdult()) {
-                allAdultPiglins.add((PiglinEntity)currentMobInMemory);
-            }
-        }
-
-        brain.remember(MemoryModuleType.NEAREST_VISIBLE_NEMESIS, nearestVisibleNemisis);
-        brain.remember(MemoryModuleType.NEAREST_VISIBLE_HUNTABLE_HOGLIN, nearestVisibleHuntableHoglin);
-        brain.remember(MemoryModuleType.NEAREST_VISIBLE_BABY_HOGLIN, nearestVisibleBabyHoglin);
-        brain.remember(MemoryModuleType.NEAREST_VISIBLE_BABY_PIGLIN, nearestVisibleBabyPiglin);
-        brain.remember(MemoryModuleType.NEAREST_VISIBLE_ZOMBIFIED, nearestVisibleZombified);
-        brain.remember(MemoryModuleType.NEAREST_TARGETABLE_PLAYER_NOT_WEARING_GOLD, nearPlayerNotInGold);
-        brain.remember(MemoryModuleType.NEAREST_PLAYER_HOLDING_WANTED_ITEM, playerHoldingWantedItem);
-        brain.remember(MemoryModuleType.NEAREST_ADULT_PIGLINS, allAdultPiglins);
-        brain.remember(MemoryModuleType.NEAREST_VISIBLE_ADULT_PIGLINS, visableAdultPiglins);
-        brain.remember(MemoryModuleType.VISIBLE_ADULT_PIGLIN_COUNT, visableAdultPiglins.size());
-        brain.remember(MemoryModuleType.VISIBLE_ADULT_HOGLIN_COUNT, visibleHoglinCount);
-        return;
+            // finish adding memories
+            brain.remember(MemoryModuleType.NEAREST_ADULT_PIGLINS, allAdultPiglins);
+            brain.remember(MemoryModuleType.VISIBLE_ADULT_PIGLIN_COUNT, allAdultPiglins.size());
+            brain.remember(MemoryModuleType.VISIBLE_ADULT_HOGLIN_COUNT, visibleHoglinCount);
+            
         }
             
         

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/entity/fast_piglin_brain/PiglinSpecificSensorMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/entity/fast_piglin_brain/PiglinSpecificSensorMixin.java
@@ -1,0 +1,215 @@
+package me.jellysquid.mods.lithium.mixin.entity.fast_piglin_brain;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import net.minecraft.entity.boss.WitherEntity;
+import net.minecraft.entity.mob.HoglinEntity;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.entity.mob.PiglinBrain;
+import net.minecraft.entity.mob.PiglinEntity;
+import net.minecraft.entity.mob.WitherSkeletonEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.predicate.entity.EntityPredicates;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.ai.brain.Brain;
+import net.minecraft.entity.ai.brain.MemoryModuleType;
+import net.minecraft.entity.ai.brain.sensor.PiglinSpecificSensor;
+
+@Mixin(PiglinSpecificSensor.class)
+public class PiglinSpecificSensorMixin {
+
+    /** A note to maintainers : 
+      * These id's are not safe between versions and most likely will change if a new mob is added,
+      * they are based on the order of entities being added to the ENTITY_TYPE registry
+      * You can check a value by getting the output of Registry.ENTITY_TYPE.get(int) 
+      * There is most likely a better way of doing this specifically however, static finals are inlined
+      * every time they are used and in a loop, inlining a check of a registry numeric id of a string isn't
+      * exactly amazing for performance.
+      * 
+      * If you are updating, check this code to make sure it is the expected entites being returned by those
+      * numeric id's.
+      * 
+      * If a new mob is added to this sensor then its ID should be added here and the accoring code added.
+    */
+    private static final int HOGLIN_ID = 33;
+    private static final int PIGLIN_ID = 60;
+    private static final int PLAYER_ID = 105;
+    private static final int ZOMBIFIED_ID = 104;
+
+
+    @Overwrite
+    protected void sense(ServerWorld world, LivingEntity entity) {
+        Brain<?> brain = entity.getBrain();
+        brain.remember(MemoryModuleType.NEAREST_REPELLENT, findSoulFire(world, entity));
+        Optional<MobEntity> nearestVisibleNemisis = Optional.empty();
+        Optional<HoglinEntity> nearestVisibleHuntableHoglin = Optional.empty();
+        Optional<HoglinEntity> nearestVisibleBabyHoglin = Optional.empty();
+        Optional<PiglinEntity> nearestVisibleBabyPiglin = Optional.empty();
+        Optional<LivingEntity> nearestVisibleZombified = Optional.empty();
+        Optional<PlayerEntity> nearPlayerNotInGold = Optional.empty();
+        Optional<PlayerEntity> playerHoldingWantedItem = Optional.empty();
+        List<PiglinEntity> visableAdultPiglins = Lists.newArrayList();
+        List<PiglinEntity> allAdultPiglins = Lists.newArrayList();
+
+        // This list appears to be sorted from nearest to furthest
+        List<LivingEntity> allVisibleMobs = (List)brain.getOptionalMemory(MemoryModuleType.VISIBLE_MOBS).orElse(ImmutableList.of());
+        Iterator visibleMobsIterator = allVisibleMobs.iterator();
+
+        Stream players = allVisibleMobs.stream().filter(EntityPredicates.EXCEPT_CREATIVE_SPECTATOR_OR_PEACEFUL);
+        Stream hoglins = allVisibleMobs.stream().filter((currentEntity) -> currentEntity.getEntityId() == HOGLIN_ID);
+        Stream piglins = allVisibleMobs.stream().filter((currentEntity) -> currentEntity.getEntityId() == PIGLIN_ID);
+        
+        brain.remember(MemoryModuleType.NEAREST_VISIBLE_ZOMBIFIED, allVisibleMobs.stream().filter((currentEntity) -> currentEntity.getEntityId()==ZOMBIFIED_ID).findFirst());
+
+        int visibleHoglinCount = 0;
+        boolean isAdult;
+
+        // prevent allocations and tons of calls each time through the loop
+        boolean foundHuntableHoglin = false;
+        boolean foundBabyHoglin = false;
+        boolean foundBabyPiglin = false;
+        boolean foundAttackablePlayer = false;
+        boolean foundPlayerHoldingGold = false;
+        boolean foundNemisis = false;
+        
+        for(LivingEntity currentLivingEntity : allVisibleMobs) {
+            // avoid many calls to isBaby() and just inline by hand to make sure
+            isAdult = !currentLivingEntity.isBaby();
+
+            /**
+             * To my knowledge, switches are faster than multiple if's.
+             * Also checking an int comparison in this case should be quicker than
+             * checking an instanceof, this should also be a bit more optimized for 
+             * the order at which things can be dectected to do early stopping in
+             * the switch statement due to how the fallthrough works.
+             * 
+             * To avoid more allocations, use casting as opposed to more variables
+             * and do so only when necessary
+             */
+            
+            switch(currentLivingEntity.getEntityId()){
+
+                // check if entity is a hoglin
+                case HOGLIN_ID : {
+                    if(isAdult) {
+                        visibleHoglinCount++;
+                        if(!foundHuntableHoglin && ((HoglinEntity)currentLivingEntity).canBeHunted()) {
+                            brain.remember(MemoryModuleType.NEAREST_VISIBLE_HUNTABLE_HOGLIN, Optional.of((HoglinEntity)currentLivingEntity));
+                            foundHuntableHoglin = true;
+                        }
+                    } else {
+                        if(!foundBabyHoglin) {
+                            brain.remember(MemoryModuleType.NEAREST_VISIBLE_BABY_HOGLIN, Optional.of((HoglinEntity)currentLivingEntity));
+                        }
+                    }
+                    break;
+                }
+
+                // check if entity is a piglin
+                case PIGLIN_ID : {
+                    if(isAdult) {
+                        visableAdultPiglins.add((PiglinEntity)currentLivingEntity);
+                    } else if(!foundBabyPiglin) {
+                        
+                    }
+                }
+            }
+
+            // stop iterating if all required targets were found
+            if(foundAttackablePlayer && foundBabyHoglin && foundBabyPiglin && foundHuntableHoglin && foundNemisis && foundPlayerHoldingGold)
+                return;
+        }
+
+        while(visibleMobsIterator.hasNext()) {
+            LivingEntity currentLivingEntity = (LivingEntity)visibleMobsIterator.next();
+
+            // Check hoglins
+            if (currentLivingEntity instanceof HoglinEntity) {
+                HoglinEntity hoglinEntity = (HoglinEntity)currentLivingEntity;
+                if (!nearestVisibleBabyHoglin.isPresent() && hoglinEntity.isBaby()) {
+                    nearestVisibleBabyHoglin = Optional.of(hoglinEntity);
+                } else if (hoglinEntity.isAdult()) {
+                    ++visibleHoglinCount;
+                    if (!nearestVisibleHuntableHoglin.isPresent() && hoglinEntity.canBeHunted()) {
+                        nearestVisibleHuntableHoglin = Optional.of(hoglinEntity);
+                    }
+                }
+
+            // check piglins
+            } else if (currentLivingEntity instanceof PiglinEntity) {
+                PiglinEntity piglinEntity = (PiglinEntity)currentLivingEntity;
+                
+                // check babies
+                if (piglinEntity.isBaby() && !nearestVisibleBabyPiglin.isPresent()) {
+                    nearestVisibleBabyPiglin = Optional.of(piglinEntity);
+                // check adults
+                } else if (piglinEntity.isAdult()) {
+                    visableAdultPiglins.add(piglinEntity);
+                }
+
+            // check players
+            } else if (currentLivingEntity instanceof PlayerEntity) {
+                PlayerEntity playerEntity = (PlayerEntity)currentLivingEntity;
+                //check player thats not in gold
+                if (!nearPlayerNotInGold.isPresent() && EntityPredicates.EXCEPT_CREATIVE_SPECTATOR_OR_PEACEFUL.test(currentLivingEntity) && !PiglinBrain.wearsGoldArmor(playerEntity)) {
+                    nearPlayerNotInGold = Optional.of(playerEntity);
+                }
+
+                // check player holding wanted item
+                if (!playerHoldingWantedItem.isPresent() && !playerEntity.isSpectator() && PiglinBrain.isGoldHoldingPlayer(playerEntity)) {
+                    playerHoldingWantedItem = Optional.of(playerEntity);
+                }
+
+            // check for nemisis
+            } else if (nearestVisibleNemisis.isPresent() || !(currentLivingEntity instanceof WitherSkeletonEntity) && !(currentLivingEntity instanceof WitherEntity)) {
+                if (!nearestVisibleZombified.isPresent() && PiglinBrain.isZombified(currentLivingEntity.getType())) {
+                    nearestVisibleZombified = Optional.of(currentLivingEntity);
+                }
+            } else {
+                nearestVisibleNemisis = Optional.of((MobEntity)currentLivingEntity);
+            }
+        }
+
+        List<LivingEntity> mobsMemory = (List)brain.getOptionalMemory(MemoryModuleType.MOBS).orElse(ImmutableList.of());
+        Iterator mobMemoryIterator = mobsMemory.iterator();
+
+        while(mobMemoryIterator.hasNext()) {
+            LivingEntity currentMobInMemory = (LivingEntity)mobMemoryIterator.next();
+            if (currentMobInMemory instanceof PiglinEntity && ((PiglinEntity)currentMobInMemory).isAdult()) {
+                allAdultPiglins.add((PiglinEntity)currentMobInMemory);
+            }
+        }
+
+        brain.remember(MemoryModuleType.NEAREST_VISIBLE_NEMESIS, nearestVisibleNemisis);
+        brain.remember(MemoryModuleType.NEAREST_VISIBLE_HUNTABLE_HOGLIN, nearestVisibleHuntableHoglin);
+        brain.remember(MemoryModuleType.NEAREST_VISIBLE_BABY_HOGLIN, nearestVisibleBabyHoglin);
+        brain.remember(MemoryModuleType.NEAREST_VISIBLE_BABY_PIGLIN, nearestVisibleBabyPiglin);
+        brain.remember(MemoryModuleType.NEAREST_VISIBLE_ZOMBIFIED, nearestVisibleZombified);
+        brain.remember(MemoryModuleType.NEAREST_TARGETABLE_PLAYER_NOT_WEARING_GOLD, nearPlayerNotInGold);
+        brain.remember(MemoryModuleType.NEAREST_PLAYER_HOLDING_WANTED_ITEM, playerHoldingWantedItem);
+        brain.remember(MemoryModuleType.NEAREST_ADULT_PIGLINS, allAdultPiglins);
+        brain.remember(MemoryModuleType.NEAREST_VISIBLE_ADULT_PIGLINS, visableAdultPiglins);
+        brain.remember(MemoryModuleType.VISIBLE_ADULT_PIGLIN_COUNT, visableAdultPiglins.size());
+        brain.remember(MemoryModuleType.VISIBLE_ADULT_HOGLIN_COUNT, visibleHoglinCount);
+        return;
+        }
+            
+        
+
+    @Shadow
+    private static Optional<BlockPos> findSoulFire(ServerWorld world, LivingEntity entity) {
+        return null;
+    }
+}

--- a/src/main/resources/lithium.mixins.json
+++ b/src/main/resources/lithium.mixins.json
@@ -61,6 +61,7 @@
         "entity.replace_entitytype_predicates.ItemFrameEntityMixin",
         "entity.stream_entity_collisions_lazily.EntityMixin",
         "entity.fast_piglin_brain.PiglinBrainMixin",
+        "entity.fast_piglin_brain.PiglinSpecificSensorMixin",
         "gen.biome_noise_cache.BiomeLayerSamplerMixin",
         "gen.biome_noise_cache.CachingLayerContextMixin",
         "gen.biome_noise_cache.ParentedLayerMixin",

--- a/src/main/resources/lithium.mixins.json
+++ b/src/main/resources/lithium.mixins.json
@@ -60,6 +60,7 @@
         "entity.replace_entitytype_predicates.FormCaravanGoalMixin",
         "entity.replace_entitytype_predicates.ItemFrameEntityMixin",
         "entity.stream_entity_collisions_lazily.EntityMixin",
+        "entity.fast_piglin_brain.PiglinBrainMixin",
         "gen.biome_noise_cache.BiomeLayerSamplerMixin",
         "gen.biome_noise_cache.CachingLayerContextMixin",
         "gen.biome_noise_cache.ParentedLayerMixin",


### PR DESCRIPTION
This is here as an optimization to how the Piglin Brain iterates through nearby piglins when doing settings with their brains, I have personally observed a non-zero difference in performance. Please let me know if there are things here to improve or any questions that anyone has.

Benchmark: I basically used [a simple test setup](https://imgur.com/a/veKjmRs) with a large amount of piglins in a small area all with vines in the spaces they stood to prevent collision lag from affecting results. I would simply go into survival with gold armor on and then mine a gold block (looking up because fps lag)

The results with this extreme of a test are quite noticeable:
[Before](https://imgur.com/a/vmNMmMu) vs [After](https://imgur.com/a/BU6TsWT)

I would also like to note that I didn't do an amazing job with creating a very consistent test setup as evidenced by the general increase in tps in the after screenshot. I believe this could be due to me starting out in survival when loading in the second time with no armor on and then attempting to reset the setup. I will attempt to provide a better benchmark at some point soon with less inconsistency but the results here still speak for themselves imo. If anyone is willing to do testing on their own that would be much appreciated. 