### PR TITLE
Correctly clean counter to fix contains method

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/util/collections/HashedReferenceList.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/util/collections/HashedReferenceList.java
@@ -266,7 +266,7 @@ public class HashedReferenceList<T> implements List<T> {
 
     @SuppressWarnings("unchecked")
     private void trackReferenceRemoved(Object o) {
-        if (this.counter.addTo((T) o, -1) <= 0) {
+        if (this.counter.addTo((T) o, -1) <= 1) {
             this.counter.removeInt(o);
         }
     }


### PR DESCRIPTION
The return value of "addTo" method returns "the old value, or the defaultreturn value if no value was present for the given key." so it has to check for 1 instead of 0 to find now empty counters. This fixes that the "containsKey" method returns true, even when the counter is at 0.