### PR TITLE
 new: use precomputed merged retracting piston base shapes and avoid VoxelShapes.union on empty shapes

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/config/LithiumConfig.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/config/LithiumConfig.java
@@ -46,6 +46,7 @@ public class LithiumConfig {
 
         this.addMixinRule("block", true);
         this.addMixinRule("block.flatten_states", true);
+        this.addMixinRule("block.moving_block_shapes", true);
 
         this.addMixinRule("cached_hashcode", true);
 

--- a/src/main/java/me/jellysquid/mods/lithium/common/shapes/OffsetVoxelShapeCache.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/shapes/OffsetVoxelShapeCache.java
@@ -1,0 +1,10 @@
+package me.jellysquid.mods.lithium.common.shapes;
+
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.shape.VoxelShape;
+
+public interface OffsetVoxelShapeCache {
+    VoxelShape getOffsetSimplifiedShape(float offset, Direction direction);
+
+    void setShape(float offset, Direction direction, VoxelShape offsetShape);
+}

--- a/src/main/java/me/jellysquid/mods/lithium/common/util/tuples/FinalObject.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/util/tuples/FinalObject.java
@@ -1,0 +1,20 @@
+package me.jellysquid.mods.lithium.common.util.tuples;
+
+/**
+ * The purpose of this class is safe publication of the wrapped value. (JLS 17.5)
+ */
+public class FinalObject<T> {
+    private final T value;
+
+    public FinalObject(T value) {
+        this.value = value;
+    }
+
+    public FinalObject<T> of(T value) {
+        return new FinalObject<>(value);
+    }
+
+    public T getValue() {
+        return value;
+    }
+}

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/block/moving_block_shapes/PistonBlockEntityMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/block/moving_block_shapes/PistonBlockEntityMixin.java
@@ -1,0 +1,125 @@
+package me.jellysquid.mods.lithium.mixin.block.moving_block_shapes;
+
+import me.jellysquid.mods.lithium.common.shapes.OffsetVoxelShapeCache;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.PistonBlock;
+import net.minecraft.block.PistonHeadBlock;
+import net.minecraft.block.entity.PistonBlockEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.util.shape.VoxelShapes;
+import net.minecraft.world.BlockView;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+
+/**
+ * @author 2No2Name
+ */
+@Mixin(PistonBlockEntity.class)
+public abstract class PistonBlockEntityMixin {
+    private static final VoxelShape[] PISTON_BASE_WITH_MOVING_HEAD_SHAPES = precomputePistonBaseWithMovingHeadShapes();
+
+    @Shadow
+    private Direction facing;
+    @Shadow
+    private boolean extending;
+    @Shadow
+    private boolean source;
+
+
+    /**
+     * Avoid calling {@link VoxelShapes#union(VoxelShape, VoxelShape)} whenever possible - use precomputed merged piston head + base shapes and
+     * cache the results for all union calls with an empty shape as first argument. (these are all other cases)
+     */
+    @Inject(method = "getCollisionShape",
+            at = @At(value = "INVOKE", shift = At.Shift.BEFORE,
+                    target = "Lnet/minecraft/util/math/Direction;getOffsetX()I"
+            ), locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true)
+    private void skipVoxelShapeUnion(BlockView world, BlockPos pos, CallbackInfoReturnable<VoxelShape> cir, VoxelShape voxelShape2, BlockState blockState2, float f) {
+        if (this.extending || !this.source) {
+            //here voxelShape2.isEmpty() is guaranteed, vanilla code would call union() which calls simplify()
+            VoxelShape blockShape = blockState2.getCollisionShape(world, pos);
+
+            //we cache the simplified shapes, as the simplify() method costs a lot of CPU time and allocates several objects
+            VoxelShape offsetAndSimplified = getOffsetAndSimplified(blockShape, Math.abs(f), f < 0f ? this.facing.getOpposite() : this.facing);
+            cir.setReturnValue(offsetAndSimplified);
+        } else {
+            //retracting piston heads have to act like their base as well, as the base block is replaced with the moving block
+            //f >= 0f is guaranteed (assuming no other mod interferes)
+            int index = getIndexForMergedShape(f, this.facing);
+            cir.setReturnValue(PISTON_BASE_WITH_MOVING_HEAD_SHAPES[index]);
+        }
+    }
+
+    /**
+     * We cache the offset and simplified VoxelShapes that are otherwise constructed on every call of getCollisionShape.
+     * For each offset direction and distance (6 directions, 2 distances each, and no direction with 0 distance) we
+     * store the offset and simplified VoxelShapes in the original VoxelShape when they are accessed the first time.
+     * We use safe publication, because both the Render and Server thread are using the cache.
+     *
+     * @param blockShape the original shape, must not be modified after passing it as an argument to this method
+     * @param offset     the offset distance
+     * @param direction  the offset direction
+     * @return blockShape offset and simplified
+     */
+    private static VoxelShape getOffsetAndSimplified(VoxelShape blockShape, float offset, Direction direction) {
+        VoxelShape offsetSimplifiedShape = ((OffsetVoxelShapeCache) blockShape).getOffsetSimplifiedShape(offset, direction);
+        if (offsetSimplifiedShape == null) {
+            //create the offset shape and store it for later use
+            offsetSimplifiedShape = blockShape.offset(direction.getOffsetX() * offset, direction.getOffsetY() * offset, direction.getOffsetZ() * offset).simplify();
+            ((OffsetVoxelShapeCache) blockShape).setShape(offset, direction, offsetSimplifiedShape);
+        }
+        return offsetSimplifiedShape;
+    }
+
+    /**
+     * Precompute all 18 possible configurations for the merged piston base and head shape.
+     *
+     * @return The array of the merged VoxelShapes, indexed by {@link PistonBlockEntityMixin#getIndexForMergedShape(float, Direction)}
+     */
+    private static VoxelShape[] precomputePistonBaseWithMovingHeadShapes() {
+        float[] offsets = {0f, 0.5f, 1f};
+        Direction[] directions = Direction.values();
+
+        VoxelShape[] mergedShapes = new VoxelShape[offsets.length * directions.length];
+
+        for (Direction facing : directions) {
+            VoxelShape baseShape = Blocks.PISTON.getDefaultState().with(PistonBlock.EXTENDED, true)
+                    .with(PistonBlock.FACING, facing).getCollisionShape(null, null);
+            for (float offset : offsets) {
+                //this cache is only required for the merged piston head + base shape.
+                //this shape is only used when !this.extending
+                //here: isShort = this.extending != 1.0F - this.progress < 0.25F can be simplified to:
+                //isShort = f < 0.25F , because f = getAmountExtended(this.progress) can be simplified to f == 1.0F - this.progress
+                //therefore isShort is dependent on the offset:
+                boolean isShort = offset < 0.25f;
+
+                VoxelShape headShape = (Blocks.PISTON_HEAD.getDefaultState().with(PistonHeadBlock.FACING, facing))
+                        .with(PistonHeadBlock.SHORT, isShort).getCollisionShape(null, null);
+
+                VoxelShape offsetHead = headShape.offset(facing.getOffsetX() * offset,
+                        facing.getOffsetY() * offset,
+                        facing.getOffsetZ() * offset);
+                mergedShapes[getIndexForMergedShape(offset, facing)] = VoxelShapes.union(baseShape, offsetHead);
+            }
+
+        }
+
+        return mergedShapes;
+    }
+
+    private static int getIndexForMergedShape(float offset, Direction direction) {
+        if (offset != 0f && offset != 0.5f && offset != 1f) {
+            return -1;
+        }
+        //shape of offset 0 is still dependent on the direction, due to piston head and base being directional blocks
+        return (int) (2 * offset) + (3 * direction.getId());
+    }
+}

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/block/moving_block_shapes/VoxelShapeMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/block/moving_block_shapes/VoxelShapeMixin.java
@@ -1,0 +1,49 @@
+package me.jellysquid.mods.lithium.mixin.block.moving_block_shapes;
+
+import me.jellysquid.mods.lithium.common.shapes.OffsetVoxelShapeCache;
+import me.jellysquid.mods.lithium.common.util.tuples.FinalObject;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.shape.VoxelShape;
+import org.spongepowered.asm.mixin.Mixin;
+
+
+@Mixin(VoxelShape.class)
+public class VoxelShapeMixin implements OffsetVoxelShapeCache {
+    private FinalObject<VoxelShape>[] offsetAndSimplified;
+
+    public void setShape(float offset, Direction direction, VoxelShape offsetShape) {
+        if (offsetShape == null) {
+            throw new IllegalArgumentException("offsetShape must not be null!");
+        }
+        int index = getIndexForOffsetSimplifiedShapes(offset, direction);
+        FinalObject<VoxelShape>[] offsetAndSimplified = this.offsetAndSimplified;
+        if (offsetAndSimplified == null) {
+            //noinspection unchecked
+            this.offsetAndSimplified = (offsetAndSimplified = new FinalObject[1 + (2 * 6)]);
+        }
+        //using FinalObject as it stores the value in a final field, which guarantees safe publication
+        offsetAndSimplified[index] = new FinalObject<>(offsetShape);
+    }
+
+    public VoxelShape getOffsetSimplifiedShape(float offset, Direction direction) {
+        FinalObject<VoxelShape>[] offsetAndSimplified = this.offsetAndSimplified;
+        if (offsetAndSimplified == null) {
+            return null;
+        }
+        int index = getIndexForOffsetSimplifiedShapes(offset, direction);
+        //usage of FinalObject guarantees that we are seeing a fully initialized VoxelShape here, even when it was created on a different thread
+        FinalObject<VoxelShape> wrappedShape = offsetAndSimplified[index];
+        //noinspection FinalObjectAssignedToNull,FinalObjectGetWithoutIsPresent
+        return wrappedShape == null ? null : wrappedShape.getValue();
+    }
+
+    private static int getIndexForOffsetSimplifiedShapes(float offset, Direction direction) {
+        if (offset != 0f && offset != 0.5f && offset != 1f) {
+            throw new IllegalArgumentException("offset must be one of {0f, 0.5f, 1f}");
+        }
+        if (offset == 0f) {
+            return 0; //can treat offsetting by 0 in all directions the same
+        }
+        return (int) (2 * offset) + 2 * direction.getId();
+    }
+}

--- a/src/main/resources/lithium.mixins.json
+++ b/src/main/resources/lithium.mixins.json
@@ -48,6 +48,8 @@
     "alloc.world_ticking.ServerWorldMixin",
     "block.flatten_states.AbstractBlockStateMixin",
     "block.flatten_states.FluidStateMixin",
+    "block.moving_block_shapes.PistonBlockEntityMixin",
+    "block.moving_block_shapes.VoxelShapeMixin",
     "cached_hashcode.BlockNeighborGroupMixin",
     "chunk.count_oversized_blocks.ChunkSectionMixin",
     "chunk.entity_class_groups.TypeFilterableListMixin",


### PR DESCRIPTION
As @jellysquid3 said on discord, getting the collision/outline shapes from moving blocks is quite an expensive call, because VoxelShapes.union is used.
Vanilla calls VoxelShapes.union for joining the piston base shape with the piston head shape for retracing pistons. As there are only a few possible configurations ( 6 directions, 3 different extension progress values), this PR precomputes all of them.

In other cases, vanilla also calls VoxelShapes.union, but with the first argument being an empty shape. The effect of this method is that the 2nd argument is "simplified" (newly constructed). We cannot skip the simplification, as e.g. a shifting floor of soul sand does not have hitboxes inside the moving blocks in vanilla, but it would have without the simplify() call. Therefore this PR uses ThreadLocal WeakHashMap's to cache the result of the simplify() call. As simplify() is only called after the shape was offset according to the moving block's progress, caching for all variants has to be done seperately.

When stepping though the debugger I noticed that the client is also calling this code very often