### PR TITLE
new: optimize VoxelShapes.matchesAnywhere using simplicity of cuboid shapes

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/shapes/VoxelShapeAlignedCuboid.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/shapes/VoxelShapeAlignedCuboid.java
@@ -133,7 +133,7 @@ public class VoxelShapeAlignedCuboid extends VoxelShapeSimpleCube {
     }
 
     @Override
-    protected DoubleList getPointPositions(Direction.Axis axis) {
+    public DoubleList getPointPositions(Direction.Axis axis) {
         return new FractionalDoubleList(axis.choose(this.xSegments, this.ySegments, this.zSegments));
     }
 

--- a/src/main/java/me/jellysquid/mods/lithium/common/shapes/VoxelShapeAlignedCuboidOffset.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/shapes/VoxelShapeAlignedCuboidOffset.java
@@ -133,7 +133,7 @@ public class VoxelShapeAlignedCuboidOffset extends VoxelShapeAlignedCuboid {
     }
 
     @Override
-    protected DoubleList getPointPositions(Direction.Axis axis) {
+    public DoubleList getPointPositions(Direction.Axis axis) {
         return new OffsetFractionalDoubleList(axis.choose(this.xSegments, this.ySegments, this.zSegments),
                 axis.choose(this.xOffset, this.yOffset, this.zOffset));
     }

--- a/src/main/java/me/jellysquid/mods/lithium/common/shapes/VoxelShapeEmpty.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/shapes/VoxelShapeEmpty.java
@@ -21,7 +21,7 @@ public class VoxelShapeEmpty extends VoxelShape implements VoxelShapeCaster {
     }
 
     @Override
-    protected DoubleList getPointPositions(Direction.Axis axis) {
+    public DoubleList getPointPositions(Direction.Axis axis) {
         return EMPTY_LIST;
     }
 

--- a/src/main/java/me/jellysquid/mods/lithium/common/shapes/VoxelShapeMatchesAnywhere.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/shapes/VoxelShapeMatchesAnywhere.java
@@ -1,0 +1,147 @@
+package me.jellysquid.mods.lithium.common.shapes;
+
+import it.unimi.dsi.fastutil.doubles.DoubleList;
+import net.minecraft.util.function.BooleanBiFunction;
+import net.minecraft.util.shape.VoxelSet;
+import net.minecraft.util.shape.VoxelShape;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import static net.minecraft.util.math.Direction.Axis.*;
+
+public class VoxelShapeMatchesAnywhere {
+
+    public static void cuboidMatchesAnywhere(VoxelShape shapeA, VoxelShape shapeB, BooleanBiFunction predicate, CallbackInfoReturnable<Boolean> cir) {
+        //calling this method only if both shapes are not empty and have bounding box overlap
+
+        if (shapeA instanceof VoxelShapeSimpleCube && shapeB instanceof VoxelShapeSimpleCube) {
+            if (((VoxelShapeSimpleCube) shapeA).isTiny || ((VoxelShapeSimpleCube) shapeB).isTiny) {
+                //vanilla fallback: Handling this special case would mean using the whole
+                //pointPosition merging code in SimplePairList. A tiny shape can have very odd effects caused by
+                //having three pointPositions within 2e-7 or even 1e-7. Vanilla merges the point positions
+                //by always taking the most negative one and skipping those with less than 1e-7 distance to it.
+                //The optimization partially relies on only having to check the previous point position, which is
+                //not possible when 3 or more are within 2e-7 of another, as the previous point position could have
+                //been skipped by the merging code.
+                return;
+            }
+            //both shapes are simple cubes, matching two cubes anywhere is really simple. Also handle epsilon margins.
+            if (predicate.apply(true, true)) {
+                if (intersects((VoxelShapeSimpleCube) shapeA, (VoxelShapeSimpleCube) shapeB)) {
+                    cir.setReturnValue(true);
+                    return;
+                }
+                cir.setReturnValue(predicate.apply(true, false) || predicate.apply(false, true));
+            } else if (predicate.apply(true, false) &&
+                    exceedsShape((VoxelShapeSimpleCube) shapeA, (VoxelShapeSimpleCube) shapeB)) {
+                cir.setReturnValue(true);
+                return;
+            } else if (predicate.apply(false, true) &&
+                    exceedsShape((VoxelShapeSimpleCube) shapeB, (VoxelShapeSimpleCube) shapeA)) {
+                cir.setReturnValue(true);
+                return;
+            }
+            cir.setReturnValue(false);
+        }
+        else if (shapeA instanceof VoxelShapeSimpleCube || shapeB instanceof VoxelShapeSimpleCube) {
+            //only one of the two shapes is a simple cube, but there are still some shortcuts that can be taken
+            VoxelShapeSimpleCube simpleCube = (VoxelShapeSimpleCube) (shapeA instanceof VoxelShapeSimpleCube ? shapeA : shapeB);
+            VoxelShape otherShape = simpleCube == shapeA ? shapeB : shapeA;
+
+            if (simpleCube.isTiny || isTiny(otherShape)) {
+                //vanilla fallback, same reason as above
+                return;
+            }
+
+            boolean acceptSimpleCubeAlone = predicate.apply(shapeA == simpleCube, shapeB == simpleCube);
+            //test the area outside otherShape
+            if (acceptSimpleCubeAlone && exceedsCube(simpleCube,
+                    otherShape.getMin(X), otherShape.getMin(Y), otherShape.getMin(Z),
+                    otherShape.getMax(X), otherShape.getMax(Y), otherShape.getMax(Z))) {
+                cir.setReturnValue(true);
+                return;
+            }
+            boolean acceptAnd = predicate.apply(true, true);
+            boolean acceptOtherShapeAlone = predicate.apply(shapeA == otherShape, shapeB == otherShape);
+
+            //test the area inside otherShape
+            VoxelSet voxelSet = otherShape.voxels;
+            DoubleList pointPositionsX = otherShape.getPointPositions(X);
+            DoubleList pointPositionsY = otherShape.getPointPositions(Y);
+            DoubleList pointPositionsZ = otherShape.getPointPositions(Z);
+
+            int xMax = voxelSet.getMax(X); // xMax <= pointPositionsX.size()
+            int yMax = voxelSet.getMax(Y);
+            int zMax = voxelSet.getMax(Z);
+
+            //keep the cube positions in local vars to avoid looking them up all the time
+            double simpleCubeMaxX = simpleCube.getMax(X);
+            double simpleCubeMinX = simpleCube.getMin(X);
+            double simpleCubeMaxY = simpleCube.getMax(Y);
+            double simpleCubeMinY = simpleCube.getMin(Y);
+            double simpleCubeMaxZ = simpleCube.getMax(Z);
+            double simpleCubeMinZ = simpleCube.getMin(Z);
+
+            //iterate over all entries of the VoxelSet
+            for (int x = voxelSet.getMin(X); x < xMax; x++) {
+                //all of the positions of +1e-7 and -1e-7 and >, >=, <, <= are carefully chosen:
+                //for example for the following line:                       >= here fails the test
+                //                                        moving the - 1e-7 here to the other side of > as + 1e-7 fails the test
+                boolean simpleCubeIntersectsXSlice = (simpleCubeMaxX - 1e-7 > pointPositionsX.getDouble(x) && simpleCubeMinX < pointPositionsX.getDouble(x + 1) - 1e-7);
+                if (!acceptOtherShapeAlone && !simpleCubeIntersectsXSlice) {
+                    //if we cannot return when the simple cube is not intersecting the area, skip forward
+                    continue;
+                }
+                boolean xSliceExceedsCube = acceptOtherShapeAlone && !((simpleCubeMaxX >= pointPositionsX.getDouble(x + 1) - 1e-7 && simpleCubeMinX - 1e-7 <= pointPositionsX.getDouble(x)));
+                for (int y = voxelSet.getMin(Y); y < yMax; y++) {
+                    boolean simpleCubeIntersectsYSlice = (simpleCubeMaxY - 1e-7 > pointPositionsY.getDouble(y) && simpleCubeMinY < pointPositionsY.getDouble(y + 1) - 1e-7);
+                    if (!acceptOtherShapeAlone && !simpleCubeIntersectsYSlice) {
+                        //if we cannot return when the simple cube is not intersecting the area, skip forward
+                        continue;
+                    }
+                    boolean ySliceExceedsCube = acceptOtherShapeAlone && !((simpleCubeMaxY >= pointPositionsY.getDouble(y + 1) - 1e-7 && simpleCubeMinY - 1e-7 <= pointPositionsY.getDouble(y)));
+                    for (int z = voxelSet.getMin(Z); z < zMax; z++) {
+                        boolean simpleCubeIntersectsZSlice = (simpleCubeMaxZ - 1e-7 > pointPositionsZ.getDouble(z) && simpleCubeMinZ < pointPositionsZ.getDouble(z + 1) - 1e-7);
+                        if (!acceptOtherShapeAlone && !simpleCubeIntersectsZSlice) {
+                            //if we cannot return when the simple cube is not intersecting the area, skip forward
+                            continue;
+                        }
+                        boolean zSliceExceedsCube = acceptOtherShapeAlone && !((simpleCubeMaxZ >= pointPositionsZ.getDouble(z + 1) - 1e-7 && simpleCubeMinZ - 1e-7 <= pointPositionsZ.getDouble(z)));
+
+                        boolean o = voxelSet.inBoundsAndContains(x, y, z);
+                        boolean s = simpleCubeIntersectsXSlice && simpleCubeIntersectsYSlice && simpleCubeIntersectsZSlice;
+                        if (acceptAnd && o && s || acceptSimpleCubeAlone && !o && s || acceptOtherShapeAlone && o && (xSliceExceedsCube || ySliceExceedsCube || zSliceExceedsCube)) {
+                            cir.setReturnValue(true);
+                            return;
+                        }
+                    }
+                }
+            }
+            cir.setReturnValue(false);
+        }
+    }
+
+    private static boolean isTiny(VoxelShape shapeA) {
+        //avoid properties of SimplePairList, really close point positions are subject to special merging behavior
+        return shapeA.getMin(X) > shapeA.getMax(X) - 3e-7 ||
+                shapeA.getMin(Y) > shapeA.getMax(Y) - 3e-7 ||
+                shapeA.getMin(Z) > shapeA.getMax(Z) - 3e-7;
+    }
+
+    private static boolean exceedsCube(VoxelShapeSimpleCube a, double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+        return a.getMin(X) < minX - 1e-7 || a.getMax(X) > maxX + 1e-7 ||
+                a.getMin(Y) < minY - 1e-7 || a.getMax(Y) > maxY + 1e-7 ||
+                a.getMin(Z) < minZ - 1e-7 || a.getMax(Z) > maxZ + 1e-7;
+    }
+
+    private static boolean exceedsShape(VoxelShapeSimpleCube a, VoxelShapeSimpleCube b) {
+        return a.getMin(X) < b.getMin(X) - 1e-7 || a.getMax(X) > b.getMax(X) + 1e-7 ||
+                a.getMin(Y) < b.getMin(Y) - 1e-7 || a.getMax(Y) > b.getMax(Y) + 1e-7 ||
+                a.getMin(Z) < b.getMin(Z) - 1e-7 || a.getMax(Z) > b.getMax(Z) + 1e-7;
+    }
+
+    private static boolean intersects(VoxelShapeSimpleCube a, VoxelShapeSimpleCube b) {
+        return a.getMin(X) < b.getMax(X) - 1e-7 && a.getMax(X) > b.getMin(X) + 1e-7 &&
+                a.getMin(Y) < b.getMax(Y) - 1e-7 && a.getMax(Y) > b.getMin(Y) + 1e-7 &&
+                a.getMin(Z) < b.getMax(Z) - 1e-7 && a.getMax(Z) > b.getMin(Z) + 1e-7;
+    }
+}

--- a/src/main/java/me/jellysquid/mods/lithium/common/shapes/VoxelShapeSimpleCube.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/shapes/VoxelShapeSimpleCube.java
@@ -25,6 +25,7 @@ public class VoxelShapeSimpleCube extends VoxelShape implements VoxelShapeCaster
     static final double EPSILON = 1.0E-7D;
 
     final double minX, minY, minZ, maxX, maxY, maxZ;
+    public final boolean isTiny;
 
     public VoxelShapeSimpleCube(VoxelSet voxels, double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
         super(voxels);
@@ -35,6 +36,11 @@ public class VoxelShapeSimpleCube extends VoxelShape implements VoxelShapeCaster
         this.maxX = maxX;
         this.maxY = maxY;
         this.maxZ = maxZ;
+
+        this.isTiny =
+                this.minX + 3 * EPSILON >= this.maxX ||
+                this.minY + 3 * EPSILON >= this.maxY ||
+                this.minZ + 3 * EPSILON >= this.maxZ;
     }
 
     @Override
@@ -146,7 +152,7 @@ public class VoxelShapeSimpleCube extends VoxelShape implements VoxelShapeCaster
     }
 
     @Override
-    protected DoubleList getPointPositions(Direction.Axis axis) {
+    public DoubleList getPointPositions(Direction.Axis axis) {
         switch (axis) {
             case X:
                 return DoubleArrayList.wrap(new double[]{this.minX, this.maxX});
@@ -166,7 +172,7 @@ public class VoxelShapeSimpleCube extends VoxelShape implements VoxelShapeCaster
 
     @Override
     public boolean isEmpty() {
-        return ((this.minX + EPSILON) > this.maxX) || ((this.minY + EPSILON) > this.maxY) || ((this.minZ + EPSILON) > this.maxZ);
+        return (this.minX >= this.maxX) || (this.minY >= this.maxY) || (this.minZ >= this.maxZ);
     }
 
     @Override

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/shapes/optimized_matching/VoxelShapesMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/shapes/optimized_matching/VoxelShapesMixin.java
@@ -1,0 +1,22 @@
+package me.jellysquid.mods.lithium.mixin.shapes.optimized_matching;
+
+import me.jellysquid.mods.lithium.common.shapes.VoxelShapeMatchesAnywhere;
+import net.minecraft.util.function.BooleanBiFunction;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.util.shape.VoxelShapes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(VoxelShapes.class)
+public class VoxelShapesMixin {
+    @Inject(method = "matchesAnywhere(Lnet/minecraft/util/shape/VoxelShape;Lnet/minecraft/util/shape/VoxelShape;Lnet/minecraft/util/function/BooleanBiFunction;)Z",
+            at = @At(value = "INVOKE", shift = At.Shift.BEFORE,
+                    target = "Lnet/minecraft/util/shape/VoxelShape;getPointPositions(Lnet/minecraft/util/math/Direction$Axis;)Lit/unimi/dsi/fastutil/doubles/DoubleList;",
+                    ordinal = 0),
+            cancellable = true)
+    private static void cuboidMatchesAnywhere(VoxelShape shapeA, VoxelShape shapeB, BooleanBiFunction predicate, CallbackInfoReturnable<Boolean> cir) {
+        VoxelShapeMatchesAnywhere.cuboidMatchesAnywhere(shapeA, shapeB, predicate, cir);
+    }
+}

--- a/src/main/resources/lithium.accesswidener
+++ b/src/main/resources/lithium.accesswidener
@@ -31,3 +31,6 @@ accessible method net/minecraft/util/shape/VoxelShapes findRequiredBitResolution
 accessible method net/minecraft/util/shape/FractionalDoubleList <init> (I)V
 
 accessible method net/minecraft/entity/Entity checkWaterState ()V
+
+accessible method net/minecraft/util/shape/VoxelShape getPointPositions (Lnet/minecraft/util/math/Direction$Axis;)Lit/unimi/dsi/fastutil/doubles/DoubleList;
+accessible field net/minecraft/util/shape/VoxelShape voxels Lnet/minecraft/util/shape/VoxelSet;

--- a/src/main/resources/lithium.mixins.json
+++ b/src/main/resources/lithium.mixins.json
@@ -93,6 +93,7 @@
     "math.fast_util.BoxMixin",
     "math.fast_util.DirectionMixin",
     "shapes.blockstate_cache.BlockMixin",
+    "shapes.optimized_matching.VoxelShapesMixin",
     "shapes.precompute_shape_arrays.FractionalDoubleListMixin",
     "shapes.precompute_shape_arrays.SimpleVoxelShapeMixin",
     "shapes.shape_merging.VoxelShapesMixin",

--- a/src/test/java/me/jellysquid/mods/lithium/mixin/shapes/optimized_matching/TestOptimizedVoxelShapeMatchesAnywhere.java
+++ b/src/test/java/me/jellysquid/mods/lithium/mixin/shapes/optimized_matching/TestOptimizedVoxelShapeMatchesAnywhere.java
@@ -1,0 +1,255 @@
+package me.jellysquid.mods.lithium.mixin.shapes.optimized_matching;
+
+import net.minecraft.block.Block;
+import net.minecraft.util.Util;
+import net.minecraft.util.function.BooleanBiFunction;
+import net.minecraft.util.math.AxisCycleDirection;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.util.shape.VoxelShapes;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import static me.jellysquid.mods.lithium.common.shapes.VoxelShapeMatchesAnywhere.cuboidMatchesAnywhere;
+import static me.jellysquid.mods.lithium.mixin.shapes.specialized_shapes.VoxelShapesMixin.cuboid;
+import static net.minecraft.block.Block.createCuboidShape;
+
+/**
+ * Test for the optimized shape matching implementation.
+ * This test compares the behavior of the optimization to vanilla code.
+ *
+ * @author 2No2Name
+ */
+public class TestOptimizedVoxelShapeMatchesAnywhere {
+    static final BooleanBiFunction[] FUNCTIONS = {BooleanBiFunction.AND, BooleanBiFunction.ONLY_FIRST, BooleanBiFunction.ONLY_SECOND, BooleanBiFunction.NOT_SAME};
+    static final VoxelShape[] TESTED_COMPLEX_SHAPES = {
+            //Cauldron:
+            VoxelShapes.combineAndSimplify(VoxelShapes.fullCube(), VoxelShapes.union(createCuboidShape(0.0D, 0.0D, 4.0D, 16.0D, 3.0D, 12.0D), createCuboidShape(4.0D, 0.0D, 0.0D, 12.0D, 3.0D, 16.0D), createCuboidShape(2.0D, 0.0D, 2.0D, 14.0D, 3.0D, 14.0D), createCuboidShape(2.0D, 4.0D, 2.0D, 14.0D, 16.0D, 14.0D)), BooleanBiFunction.ONLY_FIRST),
+            //Hopper
+            VoxelShapes.union(VoxelShapes.combineAndSimplify(VoxelShapes.union(Block.createCuboidShape(4.0D, 4.0D, 4.0D, 12.0D, 10.0D, 12.0D), Block.createCuboidShape(0.0D, 10.0D, 0.0D, 16.0D, 16.0D, 16.0D)), Block.createCuboidShape(2.0D, 11.0D, 2.0D, 14.0D, 16.0D, 14.0D), BooleanBiFunction.ONLY_FIRST), Block.createCuboidShape(12.0D, 4.0D, 6.0D, 16.0D, 8.0D, 10.0D)),
+            //Anvil
+            VoxelShapes.union(Block.createCuboidShape(2.0D, 0.0D, 2.0D, 14.0D, 4.0D, 14.0D), Block.createCuboidShape(3.0D, 4.0D, 4.0D, 13.0D, 5.0D, 12.0D), Block.createCuboidShape(4.0D, 5.0D, 6.0D, 12.0D, 10.0D, 10.0D), Block.createCuboidShape(0.0D, 10.0D, 3.0D, 16.0D, 16.0D, 13.0D)),
+            //Bell on wall
+            VoxelShapes.union(VoxelShapes.union(Block.createCuboidShape(4.0D, 4.0D, 4.0D, 12.0D, 6.0D, 12.0D), Block.createCuboidShape(5.0D, 6.0D, 5.0D, 11.0D, 13.0D, 11.0D)), Block.createCuboidShape(7.0D, 13.0D, 0.0D, 9.0D, 15.0D, 13.0D)),
+            //Bell hanging
+            VoxelShapes.union(VoxelShapes.union(Block.createCuboidShape(4.0D, 4.0D, 4.0D, 12.0D, 6.0D, 12.0D), Block.createCuboidShape(5.0D, 6.0D, 5.0D, 11.0D, 13.0D, 11.0D)), Block.createCuboidShape(7.0D, 13.0D, 7.0D, 9.0D, 16.0D, 9.0D))
+    };
+
+    public static void main(String[] args) {
+        randomTestMatchesAnywhere();
+        System.out.println("VoxelShape shape matching test passed.");
+    }
+
+    static int total = 0;
+    static int matchedAnywhere = 0;
+    static int notMatchedAnywhere = 0;
+    static int notRunModCode = 0;
+
+    private static void randomTestMatchesAnywhere() {
+        total = 0;
+        matchedAnywhere = 0;
+        notMatchedAnywhere = 0;
+        notRunModCode = 0;
+        Random random = new Random();
+        VoxelShapeVoxelShapePair pair = null;
+
+        try {
+            for (int i = 0; i < 100000000; i++) {
+                //get two random cuboid shapes that are offset so often usually barely touch or barely not touch.
+                pair = getRandomTest(random);
+                testMatchesAnywhere(pair.a, pair.b, pair.function);
+                //use one of the predefined complex non cuboid shapes and a random box randomly close to it
+                pair = getRandomTestWithComplexShape(random);
+                testMatchesAnywhere(pair.a, pair.b, pair.function);
+            }
+        } catch (Exception e) {
+            if (pair == null) {
+                throw new IllegalStateException("Test failed in initialization");
+            }
+            e.printStackTrace();
+            throw new IllegalStateException("Test failed with args: " + pair.a + ", " + pair.b + ", " + Arrays.asList(FUNCTIONS).indexOf(pair.function));
+        }
+        System.out.println("Total: " + total + "\nSkippedModCode: " + notRunModCode + "\nMatchedAnywhere: " + matchedAnywhere + "\nNotMatchedAnywhere: " + notMatchedAnywhere);
+    }
+
+    private static void testMatchesAnywhere(VoxelShape one, VoxelShape two, BooleanBiFunction function) {
+        //get the vanilla behavior to compare our implementation with
+        boolean vanillaResult = VoxelShapes.matchesAnywhere(one, two, function);
+        total++;
+        if (vanillaResult) {
+            matchedAnywhere++;
+        } else {
+            notMatchedAnywhere++;
+        }
+
+        int moddedResult = matchesAnywhereModded(one, two, function);
+        if (moddedResult == -1) {
+            notRunModCode++;
+        }
+        if ((moddedResult == 1) != vanillaResult && moddedResult != -1) {
+            //these lines only make debugging easier
+            boolean repeat = true;
+            while (repeat) {
+                int moddedResult2 = matchesAnywhereModded(one, two, function);
+                boolean vanillaResult2 = VoxelShapes.matchesAnywhere(one, two, function);
+                repeat = moddedResult2 != 10;
+            }
+
+            throw new IllegalStateException("Modded delivers unexpected result!");
+        }
+    }
+
+    private static int matchesAnywhereModded(VoxelShape shape1, VoxelShape shape2, BooleanBiFunction predicate) {
+        //code from vanilla
+        if (predicate.apply(false, false)) {
+            throw Util.throwOrPause(new IllegalArgumentException());
+        } else if (shape1 == shape2) {
+            return -1;
+        } else if (shape1.isEmpty()) {
+            return -1;
+        } else if (shape2.isEmpty()) {
+            return -1;
+        } else {
+            Direction.Axis[] var5 = AxisCycleDirection.AXES;
+            int var6 = var5.length;
+
+            for (int var7 = 0; var7 < var6; ++var7) {
+                Direction.Axis axis = var5[var7];
+                if (shape1.getMax(axis) < shape2.getMin(axis) - 1.0E-7D) {
+                    return -1;
+                }
+
+                if (shape2.getMax(axis) < shape1.getMin(axis) - 1.0E-7D) {
+                    return -1;
+                }
+            }
+            //lithium code
+            CallbackInfoReturnable<Boolean> cir = new CallbackInfoReturnable<>("matchesAnywhereModded", true);
+            cuboidMatchesAnywhere(shape1, shape2, predicate, cir);
+            if (cir.isCancelled()) {
+                return cir.getReturnValueZ() ? 1 : 0;
+            }
+            return -1;
+        }
+    }
+
+
+    public static VoxelShapeVoxelShapePair getRandomTest(Random random) {
+        double x = random.nextInt(1000) - 500 + random.nextDouble();
+        double y = random.nextInt(1000) - 500 + random.nextDouble();
+        double z = random.nextInt(1000) - 500 + random.nextDouble();
+
+        double xRadius = random.nextInt(3) + random.nextDouble() - 0.01;
+        double yRadius = random.nextInt(3) + random.nextDouble() - 0.01;
+        double zRadius = random.nextInt(3) + random.nextDouble() - 0.01;
+
+        Box a = new Box(x - xRadius, y - yRadius, z - zRadius, x + xRadius, y + yRadius, z + zRadius);
+
+        double xRadius2 = random.nextInt(3) + random.nextDouble() - 0.01;
+        double yRadius2 = random.nextInt(3) + random.nextDouble() - 0.01;
+        double zRadius2 = random.nextInt(3) + random.nextDouble() - 0.01;
+
+        Direction touchSide = Direction.random(random);
+
+        if (random.nextInt(8) > 0) {
+            x += touchSide.getOffsetX() * (xRadius + xRadius2);
+            y += touchSide.getOffsetY() * (yRadius + yRadius2);
+            z += touchSide.getOffsetZ() * (zRadius + zRadius2);
+        }
+
+        x = getFuzzy(x, random, xRadius + xRadius2, 0.25f, 0.25f, 0.2f);
+        y = getFuzzy(y, random, yRadius + yRadius2, 0.25f, 0.25f, 0.2f);
+        z = getFuzzy(z, random, zRadius + zRadius2, 0.25f, 0.25f, 0.2f);
+
+        Box b = new Box(x - xRadius2, y - yRadius2, z - zRadius2, x + xRadius2, y + yRadius2, z + zRadius2);
+
+        BooleanBiFunction function = Util.getRandom(FUNCTIONS, random);
+
+        if (random.nextBoolean()) {
+            return new VoxelShapeVoxelShapePair(cuboid(b), cuboid(a), function);
+        }
+        return new VoxelShapeVoxelShapePair(cuboid(a), cuboid(b), function);
+    }
+
+
+    private static VoxelShapeVoxelShapePair getRandomTestWithComplexShape(Random random) {
+        VoxelShape complexShape = Util.getRandom(TESTED_COMPLEX_SHAPES, random);
+        if (random.nextInt(8) > 1) {
+            complexShape = complexShape.offset(
+                    getFuzzy(random.nextInt(5) - 2, random, 0, 0.25f, 0.5f, 0f),
+                    getFuzzy(random.nextInt(5) - 2, random, 0, 0.25f, 0.5f, 0f),
+                    getFuzzy(random.nextInt(5) - 2, random, 0, 0.25f, 0.5f, 0f));
+        }
+        double x = 0.5D * (complexShape.getMin(Direction.Axis.X) + complexShape.getMax(Direction.Axis.X));
+        double y = 0.5D * (complexShape.getMin(Direction.Axis.Y) + complexShape.getMax(Direction.Axis.Y));
+        double z = 0.5D * (complexShape.getMin(Direction.Axis.Z) + complexShape.getMax(Direction.Axis.Z));
+
+        double xRadius = 0.5D * (complexShape.getMax(Direction.Axis.X) - complexShape.getMin(Direction.Axis.X));
+        double yRadius = 0.5D * (complexShape.getMax(Direction.Axis.Y) - complexShape.getMin(Direction.Axis.Y));
+        double zRadius = 0.5D * (complexShape.getMax(Direction.Axis.Z) - complexShape.getMin(Direction.Axis.Z));
+
+        double xRadius2 = random.nextInt(3) + random.nextDouble() - 0.01;
+        double yRadius2 = random.nextInt(3) + random.nextDouble() - 0.01;
+        double zRadius2 = random.nextInt(3) + random.nextDouble() - 0.01;
+
+        Direction touchSide = Direction.random(random);
+
+        if (random.nextInt(8) > 0) {
+            x += touchSide.getOffsetX() * (xRadius + xRadius2);
+            y += touchSide.getOffsetY() * (yRadius + yRadius2);
+            z += touchSide.getOffsetZ() * (zRadius + zRadius2);
+        }
+
+        x = getFuzzy(x, random, xRadius + xRadius2, 0.25f, 0.25f, 0.25f);
+        y = getFuzzy(y, random, yRadius + yRadius2, 0.25f, 0.25f, 0.25f);
+        z = getFuzzy(z, random, zRadius + zRadius2, 0.25f, 0.25f, 0.25f);
+
+        Box b = new Box(x - xRadius2, y - yRadius2, z - zRadius2, x + xRadius2, y + yRadius2, z + zRadius2);
+
+        BooleanBiFunction function = Util.getRandom(FUNCTIONS, random);
+
+        if (random.nextBoolean()) {
+            return new VoxelShapeVoxelShapePair(complexShape, cuboid(b), function);
+        }
+        return new VoxelShapeVoxelShapePair(cuboid(b), complexShape, function);
+    }
+
+    private static double getFuzzy(double val, Random random, double specialValue, float chanceFuzz, float chanceBigFuzz, float chanceSpecialOffset) {
+        if (random.nextFloat() < chanceFuzz) {
+            if (random.nextInt(8) > 1) {
+                val += 3e-7 * random.nextDouble() * (random.nextInt(2) * 2 - 1);
+            } else {
+                //test exactly around 1e-7 offsets
+                val += (random.nextInt(3) - 1) * 1e-7;
+
+                boolean b = random.nextBoolean();
+                for (int i = random.nextInt(9) + 1; i > 0; i--) {
+                    val = b ? Math.nextUp(val) : Math.nextDown(val);
+                }
+            }
+
+            if (random.nextFloat() < chanceSpecialOffset) {
+                val += (random.nextBoolean() ? 1 : -1) * specialValue;
+            }
+
+            if (random.nextFloat() < chanceBigFuzz) {
+                val += random.nextGaussian();
+            }
+        }
+        return val;
+    }
+
+    private static class VoxelShapeVoxelShapePair {
+        final VoxelShape a, b;
+        final BooleanBiFunction function;
+
+        private VoxelShapeVoxelShapePair(VoxelShape a, VoxelShape b, BooleanBiFunction function) {
+            this.a = a;
+            this.b = b;
+            this.function = function;
+        }
+    }
+}


### PR DESCRIPTION
This PR avoids the allocations in VoxelShapes.matchesAnywhere (PairLists and lambdas) in cases where it is called with at least one cuboid shape as argument. If both arguments are cuboid shapes the collision calculation is very simple.
The correctness was tested by randomly trying out millions of collisions.
Performance testing still needs to be done