### PR TITLE
change: allow compatibility with both 1.16.2 and 1.16.3

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
     "accessWidener": "lithium.accesswidener",
     "depends": {
         "fabricloader": ">=0.9.0",
-        "minecraft": "1.16.3"
+        "minecraft": ["1.16.2", "1.16.3"]
     },
     "breaks": {
         "optifabric": "*"


### PR DESCRIPTION
The differences between 1.16.2 and 1.16.3 are minor and don't interact with Lithium.
It seems that people are continuing to use 1.16.2, so it'd be nice to allow future versions of Lithium to run there. Otherwise people are forced to use an outdated version or edit the .jar manually.