### PR TITLE
Fix the description text for lithium API directory.

### DIFF
--- a/api/src/main/resources/fabric.mod.json
+++ b/api/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
     "id": "lithium-api",
     "version": "${version}",
     "name": "Lithium API",
-    "description": "Lithium is an free and open-source optimization mod for Minecraft which makes a wide range of performance improvements to the game.",
+    "description": "Lithium is a free and open-source optimization mod for Minecraft which makes a wide range of performance improvements to the game.",
     "authors": [
         "JellySquid"
     ],


### PR DESCRIPTION
[A similar pull request](https://github.com/jellysquid3/lithium-fabric/pull/159) was already made showing the grammar error for lithium's json file, This one is from the API itself instead.

This may also likely apply to the stable branch instead of just dev.