### PR TITLE
Implement a faster biome array implementation for the overworld

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/config/LithiumConfig.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/config/LithiumConfig.java
@@ -74,6 +74,7 @@ public class LithiumConfig {
         this.addMixinRule("gen", true);
         this.addMixinRule("gen.biome_noise_cache", true);
         this.addMixinRule("gen.chunk_region", true);
+        this.addMixinRule("gen.fast_biome_array", true);
         this.addMixinRule("gen.fast_island_noise", true);
         this.addMixinRule("gen.fast_layer_sampling", true);
         this.addMixinRule("gen.fast_multi_source_biomes", true);

--- a/src/main/java/me/jellysquid/mods/lithium/common/world/biome/HorizontalBiomeArray.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/world/biome/HorizontalBiomeArray.java
@@ -1,0 +1,46 @@
+package me.jellysquid.mods.lithium.common.world.biome;
+
+import net.minecraft.util.collection.IndexedIterable;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.source.BiomeArray;
+import net.minecraft.world.biome.source.BiomeSource;
+
+/**
+ * Biome array that samples in the horizontal axis and uses that to fill in the vertical axis, skipping a majority of calls to the biome source.
+ * This should only be used when the dimension's biome access type is also horizontal.
+ */
+public class HorizontalBiomeArray extends BiomeArray {
+    private static final int HORIZONTAL_SECTION_COUNT = (int)Math.round(Math.log(16.0D) / Math.log(2.0D)) - 2;
+    private static final int HORIZONTAL_BITS = HORIZONTAL_SECTION_COUNT * 2;
+
+    public HorizontalBiomeArray(IndexedIterable<Biome> indexedIterable, ChunkPos pos, BiomeSource source) {
+        super(indexedIterable, sampleBiomes(pos, source));
+    }
+
+    private static Biome[] sampleBiomes(ChunkPos pos, BiomeSource source) {
+        // Get the start of the biome sampling section, which is 4x4 blocks wide
+        int startX = pos.getStartX() >> 2;
+        int startZ = pos.getStartZ() >> 2;
+
+        Biome[] biomes = new Biome[DEFAULT_LENGTH];
+
+        // Iterate from 0 to 16
+        for (int index = 0; index < (1 << HORIZONTAL_BITS); ++index) {
+            // Mask the bottom 4 to get the x coord
+            int biomeX = index & HORIZONTAL_BIT_MASK;
+            // Move the top 4 bits and the mask to get the z coord
+            int biomeZ = (index >> HORIZONTAL_SECTION_COUNT) & HORIZONTAL_BIT_MASK;
+
+            // Sample the biome at this position
+            Biome biome = source.getBiomeForNoiseGen(startX + biomeX, 0, startZ + biomeZ);
+
+            // Fill in all of the vertical bits with the biome
+            for (int y = 0; y <= VERTICAL_BIT_MASK; y++) {
+                biomes[index | (y << HORIZONTAL_BITS)] = biome;
+            }
+        }
+
+        return biomes;
+    }
+}

--- a/src/main/java/me/jellysquid/mods/lithium/common/world/biome/HorizontalBiomeArray.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/world/biome/HorizontalBiomeArray.java
@@ -8,7 +8,7 @@ import net.minecraft.world.biome.source.BiomeSource;
 
 /**
  * Biome array that samples in the horizontal axis and uses that to fill in the vertical axis, skipping a majority of calls to the biome source.
- * This should only be used when the dimension's biome access type is also horizontal.
+ * This should only be used when the dimension's biome access type is also horizontal, such as in the overworld.
  */
 public class HorizontalBiomeArray extends BiomeArray {
     private static final int HORIZONTAL_SECTION_COUNT = (int)Math.round(Math.log(16.0D) / Math.log(2.0D)) - 2;

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/gen/fast_biome_array/ChunkStatusMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/gen/fast_biome_array/ChunkStatusMixin.java
@@ -1,0 +1,28 @@
+package me.jellysquid.mods.lithium.mixin.gen.fast_biome_array;
+
+import java.util.List;
+
+import me.jellysquid.mods.lithium.common.world.biome.HorizontalBiomeArray;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.biome.source.HorizontalVoronoiBiomeAccessType;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.ChunkStatus;
+import net.minecraft.world.chunk.ProtoChunk;
+import net.minecraft.world.gen.chunk.ChunkGenerator;
+
+@Mixin(ChunkStatus.class)
+public class ChunkStatusMixin {
+    @Inject(method = "method_16570", at = @At("HEAD"), remap = false, cancellable = true)
+    private static void populateBiomes(ServerWorld world, ChunkGenerator generator, List<Chunk> surroundingChunks, Chunk chunk, CallbackInfo info) {
+        if (world.getDimension().getBiomeAccessType() instanceof HorizontalVoronoiBiomeAccessType) {
+            ((ProtoChunk) chunk).setBiomes(new HorizontalBiomeArray(world.getRegistryManager().get(Registry.BIOME_KEY), chunk.getPos(), generator.getBiomeSource()));
+
+            info.cancel();
+        }
+    }
+}

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/gen/fast_biome_array/ChunkStatusMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/gen/fast_biome_array/ChunkStatusMixin.java
@@ -17,12 +17,20 @@ import net.minecraft.world.gen.chunk.ChunkGenerator;
 
 @Mixin(ChunkStatus.class)
 public class ChunkStatusMixin {
+
+    /**
+     * We inject into the lambda in the BIOME status to construct a horizontal biome array if the biome access type is horizontal.
+     * Since the method is a lambda, it's not mapped and the unresolved mixin warning can be ignored.
+     *
+     * @author SuperCoder79
+     */
+    @SuppressWarnings("UnresolvedMixinReference")
     @Inject(method = "method_16570", at = @At("HEAD"), remap = false, cancellable = true)
-    private static void populateBiomes(ServerWorld world, ChunkGenerator generator, List<Chunk> surroundingChunks, Chunk chunk, CallbackInfo info) {
+    private static void populateBiomes(ServerWorld world, ChunkGenerator generator, List<Chunk> surroundingChunks, Chunk chunk, CallbackInfo ci) {
         if (world.getDimension().getBiomeAccessType() instanceof HorizontalVoronoiBiomeAccessType) {
             ((ProtoChunk) chunk).setBiomes(new HorizontalBiomeArray(world.getRegistryManager().get(Registry.BIOME_KEY), chunk.getPos(), generator.getBiomeSource()));
 
-            info.cancel();
+            ci.cancel();
         }
     }
 }

--- a/src/main/resources/lithium.mixins.json
+++ b/src/main/resources/lithium.mixins.json
@@ -80,6 +80,7 @@
     "gen.biome_noise_cache.MergingLayerMixin",
     "gen.biome_noise_cache.ParentedLayerMixin",
     "gen.chunk_region.ChunkRegionMixin",
+    "gen.fast_biome_array.ChunkStatusMixin",
     "gen.fast_island_noise.NoiseChunkGeneratorMixin",
     "gen.fast_island_noise.TheEndBiomeSourceMixin",
     "gen.fast_layer_sampling.CachingLayerContextMixin",


### PR DESCRIPTION
With the introduction of vertical biome support in 1.15, biome storage has moved from a 16 * 16 array in favor of a 4 * 64 * 4 low-resolution array where each element represents a 4x4x4 cube which is then upscaled to represent the whole chunk. While the nether and end use 3d upscaling via `VoronoiBiomeAccessType`, the overworld uses 2d upscaling through `HorizontalVoronoiBiomeAccessType`, so we can get away with only sampling the horizontal coords and using it to fill in the rest of the column. A quick sampling shows a **2x** improvement in biome array setting times. Granted, it wasn't much to begin with in vanilla, but with more complicated biome layer setups this can make a huge difference.
Before:
![image](https://user-images.githubusercontent.com/25208576/103159773-83b34900-479b-11eb-8504-23de4a165cd1.png)
After:
![image](https://user-images.githubusercontent.com/25208576/103159780-962d8280-479b-11eb-8027-f7dd04303b12.png)

I would like to thank @alcatrazEscapee for the original implementation of this patch and allowing the usage of his code :)