### PR TITLE
Implement a cache for chunk generator settings

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/gen/cached_generator_settings/NoiseChunkGeneratorMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/gen/cached_generator_settings/NoiseChunkGeneratorMixin.java
@@ -2,8 +2,10 @@ package me.jellysquid.mods.lithium.mixin.gen.cached_generator_settings;
 
 import java.util.function.Supplier;
 
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -14,21 +16,23 @@ import net.minecraft.world.gen.chunk.NoiseChunkGenerator;
 
 @Mixin(NoiseChunkGenerator.class)
 public class NoiseChunkGeneratorMixin {
-    private Lazy<ChunkGeneratorSettings> chunkGeneratorSettings;
-
-    @Inject(method = "<init>(Lnet/minecraft/world/biome/source/BiomeSource;Lnet/minecraft/world/biome/source/BiomeSource;JLjava/util/function/Supplier;)V", at = @At("RETURN"))
-    private void initializeLazy(BiomeSource populationSource, BiomeSource biomeSource, long seed, Supplier<ChunkGeneratorSettings> settings, CallbackInfo ci) {
-        this.chunkGeneratorSettings = new Lazy<>(settings);
-    }
+    @Shadow
+    @Final
+    protected Supplier<ChunkGeneratorSettings> settings;
+    private int cachedSeaLevel = Integer.MIN_VALUE;
 
     /**
-     * Use cached chunk generator settings instead of retrieving from the registry every time.
+     * Use cached sea level instead of retrieving from the registry every time.
      * This method is called for every block in the chunk so this will save a lot of registry lookups.
      *
      * @author SuperCoder79
      */
     @Overwrite
     public int getSeaLevel() {
-        return this.chunkGeneratorSettings.get().getSeaLevel();
+        if (this.cachedSeaLevel == Integer.MIN_VALUE) {
+            this.cachedSeaLevel = this.settings.get().getSeaLevel();
+        }
+
+        return this.cachedSeaLevel;
     }
 }

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/gen/cached_generator_settings/NoiseChunkGeneratorMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/gen/cached_generator_settings/NoiseChunkGeneratorMixin.java
@@ -1,0 +1,34 @@
+package me.jellysquid.mods.lithium.mixin.gen.cached_generator_settings;
+
+import java.util.function.Supplier;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import net.minecraft.util.Lazy;
+import net.minecraft.world.biome.source.BiomeSource;
+import net.minecraft.world.gen.chunk.ChunkGeneratorSettings;
+import net.minecraft.world.gen.chunk.NoiseChunkGenerator;
+
+@Mixin(NoiseChunkGenerator.class)
+public class NoiseChunkGeneratorMixin {
+    private Lazy<ChunkGeneratorSettings> chunkGeneratorSettings;
+
+    @Inject(method = "<init>(Lnet/minecraft/world/biome/source/BiomeSource;Lnet/minecraft/world/biome/source/BiomeSource;JLjava/util/function/Supplier;)V", at = @At("RETURN"))
+    private void initializeLazy(BiomeSource populationSource, BiomeSource biomeSource, long seed, Supplier<ChunkGeneratorSettings> settings, CallbackInfo ci) {
+        this.chunkGeneratorSettings = new Lazy<>(settings);
+    }
+
+    /**
+     * Use cached chunk generator settings instead of retrieving from the registry every time.
+     * This method is called for every block in the chunk so this will save a lot of registry lookups.
+     *
+     * @author SuperCoder79
+     */
+    @Overwrite
+    public int getSeaLevel() {
+        return this.chunkGeneratorSettings.get().getSeaLevel();
+    }
+}

--- a/src/main/resources/lithium.mixins.json
+++ b/src/main/resources/lithium.mixins.json
@@ -79,6 +79,7 @@
     "gen.biome_noise_cache.InitLayerMixin",
     "gen.biome_noise_cache.MergingLayerMixin",
     "gen.biome_noise_cache.ParentedLayerMixin",
+    "gen.cached_generator_settings.NoiseChunkGeneratorMixin",
     "gen.chunk_region.ChunkRegionMixin",
     "gen.fast_island_noise.NoiseChunkGeneratorMixin",
     "gen.fast_island_noise.TheEndBiomeSourceMixin",


### PR DESCRIPTION
Chunk generator settings are passed to the noise chunk generator through a supplier, which retrieves a given chunk generator settings registry key from the registry. The problem arises as this setting is retrieved from the supplier to get the sea level, which is called **every single time a block is placed by the generator, for a total of 65536 registry lookups per chunk.** As you can imagine this isn't all that fast and removing it speeds up the chunk generation time by a moderate amount (13% of CPU time spent in populateNoise without the patch vs 10% with the patch). My solution to this was to stick the supplier into a Lazy<> so it's computed once and then cached, but I'm open to suggestions. (The sea level can't be computed ahead of time due to a quirk in the new registry system, which would have been the best option here.)