### PR TITLE
Extend ChunkRegionMixin to use the chunk array for setBlockState and getTopY

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/gen/chunk_region/ChunkRegionMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/gen/chunk_region/ChunkRegionMixin.java
@@ -6,6 +6,8 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.ChunkRegion;
+import net.minecraft.world.Heightmap;
+import net.minecraft.world.WorldView;
 import net.minecraft.world.chunk.Chunk;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -13,6 +15,7 @@ import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.List;
@@ -55,6 +58,39 @@ public abstract class ChunkRegionMixin {
             return this.chunksArr[x + z * w].getBlockState(pos);
         } else {
             throw new NullPointerException("No chunk exists at " + new ChunkPos(pos));
+        }
+    }
+
+    /**
+     * @reason Use the chunk array for faster access
+     */
+    @Redirect(method = "setBlockState", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/ChunkRegion;getChunk(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/world/chunk/Chunk;"), remap = true)
+    private Chunk fastGetChunk(ChunkRegion world, BlockPos pos) {
+        int x = (pos.getX() >> 4) - this.minChunkX;
+        int z = (pos.getZ() >> 4) - this.minChunkZ;
+        int w = this.width;
+
+        if (x >= 0 && z >= 0 && x < w && z < w) {
+            return this.chunksArr[x + z * w];
+        } else {
+            throw new NullPointerException("No chunk exists at " + new ChunkPos(pos));
+        }
+    }
+
+    /**
+     * @reason Avoid pointer de-referencing, make method easier to inline
+     * @author SuperCoder79
+     */
+    @Overwrite
+    public int getTopY(Heightmap.Type heightmap, int x, int z) {
+        int chunkX = (x >> 4) - this.minChunkX;
+        int chunkZ = (z >> 4) - this.minChunkZ;
+        int w = this.width;
+
+        if (chunkX >= 0 && chunkZ >= 0 && chunkX < w && chunkZ < w) {
+            return this.chunksArr[chunkX + chunkZ * w].sampleHeightmap(heightmap, x & 15, z & 15) + 1;
+        } else {
+            throw new NullPointerException("No chunk exists at " + new ChunkPos(chunkX, chunkZ));
         }
     }
 


### PR DESCRIPTION
This PR adds to ChunkRegionMixin by using the faster chunk array for the setBlockState and getTopY methods to avoid pointer dereferencing and making them easier to inline, like the existing getBlockState method. With some profiling this speeds up worldgen time by about 10% compared to without the patch. My one concern with this change is should the chunk array access be extracted to another method as the code is reused a few times- I was going to do that but I was unsure how it would affect the said goal of making the method easier to inline. 