### PR TITLE
Fix gradle mavenLocal publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,14 +60,6 @@ allprojects {
         options.encoding = "UTF-8"
     }
 
-    publishing {
-        publications {
-            mavenJava(MavenPublication) {
-                artifact(remapJar)
-            }
-        }
-    }
-
     jar {
         from "${rootDir}/LICENSE.txt"
     }
@@ -78,6 +70,20 @@ dependencies {
 
     afterEvaluate {
         include project(":lithium-api")
+    }
+}
+
+publishing {
+    publications {
+        main (MavenPublication) {
+            artifactId "lithium"
+            artifact(remapJar)
+        }
+
+        api (MavenPublication) {
+            artifactId "lithium-api"
+            artifact(project(":lithium-api").tasks.remapJar)
+        }
     }
 }
 


### PR DESCRIPTION
The split from lithium-api caused an issue where lithium couldn't be pushed to maven local, which [broke JitPack](https://jitpack.io/com/github/jellysquid3/lithium-fabric/mc1.16.4-0.6.0/build.log). This seems to be caused by how the `allProjects` block works, causing both lithium and lithium-api to be published under the same artifactId. Explicitly setting the artifactId to be the `project.name`, despite making perfect sense to me, didn't seem to work.

This pr fixes the issue by removing the publishing block from `allProjects`. Instead it defines a single publishing block for the main lithium project and declares both lithium and lithium-api as artifacts. 

It may be possible to define a publishing block for both projects, one each. This may be slightly cleaner but I believe it would require a separate gradle.build for the api.

These changes make JitPack import the project [properly](https://jitpack.io/#theepicblock/lithium-fabric/publish_maven_local_fix-SNAPSHOT) and makes them available under `com.github.com.github.jellysquid3.lithium-fabric:lithium:Tag` and  
`com.github.com.github.jellysquid3.lithium-fabric:lithium-api:Tag`.
JitPack previously published them as `com.github.com.github.jellysquid3.lithium-fabric:Tag`; I believe this change is unavoidable due to lithium now being a multiproject.