### PR TITLE
new: optimized redstone wire

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/config/LithiumConfig.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/config/LithiumConfig.java
@@ -59,6 +59,7 @@ public class LithiumConfig {
         this.addMixinRule("block.flatten_states", true);
         this.addMixinRule("block.hopper", true);
         this.addMixinRule("block.moving_block_shapes", true);
+        this.addMixinRule("block.redstone_wire", true);
 
         this.addMixinRule("cached_hashcode", true);
 

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/block/redstone_wire/RedstoneWireBlockMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/block/redstone_wire/RedstoneWireBlockMixin.java
@@ -1,0 +1,151 @@
+package me.jellysquid.mods.lithium.mixin.block.redstone_wire;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.RedstoneWireBlock;
+import net.minecraft.state.property.Properties;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
+
+/**
+ * @author Space Walker
+ */
+@Mixin(RedstoneWireBlock.class)
+public class RedstoneWireBlockMixin extends Block {
+
+    private static final Direction[] DIRECTIONS = Direction.values();
+    private static final Direction[] DIRECTIONS_VIRTICAL = { Direction.DOWN, Direction.UP };
+    private static final Direction[] DIRECTIONS_HORIZONTAL = { Direction.WEST, Direction.EAST, Direction.NORTH, Direction.SOUTH };
+
+    private static final int MIN = 0;
+    private static final int MAX = 15;
+    private static final int MAX_WIRE = MAX - 1;
+
+    public RedstoneWireBlockMixin(Settings settings) {
+        super(settings);
+    }
+
+    @Inject(
+            method = "getReceivedRedstonePower",
+            cancellable = true,
+            at = @At(
+                    value = "HEAD"
+            )
+    )
+    private void getReceivedPowerFaster(World world, BlockPos pos, CallbackInfoReturnable<Integer> cir) {
+        cir.setReturnValue(this.getReceivedPower(world, pos));
+        cir.cancel();
+    }
+
+    private int getReceivedPower(World world, BlockPos pos) {
+        int power = MIN;
+        
+        for (Direction dir : DIRECTIONS_VIRTICAL) {
+            power = Math.max(power, this.getPowerFromVertical(world, pos.offset(dir), dir));
+            
+            if (power >= MAX) {
+                return MAX;
+            }
+        }
+        
+        BlockPos up = pos.up();
+        boolean checkWiresAbove = world.getBlockState(up).isSolidBlock(world, up);
+        
+        for (Direction dir : DIRECTIONS_HORIZONTAL) {
+            power = Math.max(power, this.getPowerFromSide(world, pos.offset(dir), dir, checkWiresAbove));
+            
+            if (power >= MAX) {
+                return MAX;
+            }
+        }
+        
+        return power;
+    }
+
+    private int getPowerFromVertical(World world, BlockPos pos, Direction toDir) {
+        BlockState state = world.getBlockState(pos);
+        
+        if (state.isOf(this) || state.isAir()) {
+            return MIN;
+        }
+        
+        int power = state.getWeakRedstonePower(world, pos, toDir);
+        
+        if (power >= MAX) {
+            return MAX;
+        }
+        
+        if (state.isSolidBlock(world, pos)) {
+            return Math.max(power, this.getStrongPowerTo(world, pos, toDir));
+        }
+        
+        return power;
+    }
+
+    private int getPowerFromSide(World world, BlockPos pos, Direction toDir, boolean checkWiresAbove) {
+        BlockState state = world.getBlockState(pos);
+        
+        if (state.isOf(this)) {
+            return state.get(Properties.POWER) - 1;
+        }
+        
+        int power = state.getWeakRedstonePower(world, pos, toDir);
+        
+        if (power >= MAX) {
+            return MAX;
+        }
+        
+        if (state.isSolidBlock(world, pos)) {
+            power = Math.max(power, this.getStrongPowerTo(world, pos, toDir));
+            
+            if (power >= MAX) {
+                return MAX;
+            }
+            
+            if (checkWiresAbove && power < MAX_WIRE) {
+                BlockPos up = pos.up();
+                BlockState aboveState = world.getBlockState(up);
+                
+                if (aboveState.isOf(this)) {
+                    power = Math.max(power, aboveState.get(Properties.POWER) - 1);
+                }
+            }
+        } else if (power < MAX_WIRE) {
+            BlockPos down = pos.down();
+            BlockState aboveState = world.getBlockState(down);
+            
+            if (aboveState.isOf(this)) {
+                power = Math.max(power, aboveState.get(Properties.POWER) - 1);
+            }
+        }
+        
+        return power;
+    }
+
+    private int getStrongPowerTo(World world, BlockPos pos, Direction ignore) {
+        int power = MIN;
+        
+        for (Direction dir : DIRECTIONS) {
+            if (dir != ignore) {
+                BlockPos side = pos.offset(dir);
+                BlockState neighbor = world.getBlockState(side);
+                
+                if (!neighbor.isOf(this) && !neighbor.isAir()) {
+                    power = Math.max(power, neighbor.getStrongRedstonePower(world, side, dir));
+                    
+                    if (power >= MAX) {
+                        return MAX;
+                    }
+                }
+            }
+        }
+        
+        return power;
+    }
+}

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/block/redstone_wire/RedstoneWireBlockMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/block/redstone_wire/RedstoneWireBlockMixin.java
@@ -94,7 +94,7 @@ public class RedstoneWireBlockMixin extends Block {
         
         // In vanilla this check is done up to 4 times.
         BlockPos up = pos.up();
-        boolean checkWiresAbove = world.getBlockState(up).isSolidBlock(world, up);
+        boolean checkWiresAbove = !world.getBlockState(up).isSolidBlock(world, up);
         
         for (Direction dir : DIRECTIONS_HORIZONTAL) {
             power = Math.max(power, this.getPowerFromSide(world, pos.offset(dir), dir, checkWiresAbove));

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/block/redstone_wire/RedstoneWireBlockMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/block/redstone_wire/RedstoneWireBlockMixin.java
@@ -55,7 +55,7 @@ import net.minecraft.world.World;
 public class RedstoneWireBlockMixin extends Block {
     
     private static final Direction[] DIRECTIONS = Direction.values();
-    private static final Direction[] DIRECTIONS_VIRTICAL = { Direction.DOWN, Direction.UP };
+    private static final Direction[] DIRECTIONS_VERTICAL = { Direction.DOWN, Direction.UP };
     private static final Direction[] DIRECTIONS_HORIZONTAL = { Direction.WEST, Direction.EAST, Direction.NORTH, Direction.SOUTH };
     
     private static final int MIN = 0;            // smallest possible power value
@@ -75,7 +75,6 @@ public class RedstoneWireBlockMixin extends Block {
     )
     private void getReceivedPowerFaster(World world, BlockPos pos, CallbackInfoReturnable<Integer> cir) {
         cir.setReturnValue(this.getReceivedPower(world, pos));
-        cir.cancel();
     }
     
     /**
@@ -85,7 +84,7 @@ public class RedstoneWireBlockMixin extends Block {
     private int getReceivedPower(World world, BlockPos pos) {
         int power = MIN;
         
-        for (Direction dir : DIRECTIONS_VIRTICAL) {
+        for (Direction dir : DIRECTIONS_VERTICAL) {
             power = Math.max(power, this.getPowerFromVertical(world, pos.offset(dir), dir));
             
             if (power >= MAX) {

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/block/redstone_wire/RedstoneWireBlockMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/block/redstone_wire/RedstoneWireBlockMixin.java
@@ -14,23 +14,58 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 
 /**
+ * Optimizing redstone dust is tricky, but even more so if you wish to preserve behavior
+ * perfectly. There are two big reasons redstone wire is laggy:
+ * <br>
+ * - It updates recursively. Each wire updates its power level in isolation, rather than
+ *   in the context of the network it is a part of. This means each wire in a network
+ *   could check and update its power level over half a dozen times. This also leads to
+ *   way more shape and block updates than necessary.
+ * <br>
+ * - It emits copious amounts of duplicate and redundant shape and block updates. While
+ *   the recursive updates are largely to blame, even a single state change leads to 18
+ *   redundant block updates and up to 16 redundant shape updates.
+ * 
+ * <p>
+ * Unfortunately fixing either of these aspects can be detected in-game, even if it is
+ * through obscure mechanics. Removing redundant block updates can be detected with
+ * something as simple as a redstone wire on a trapdoor, while removing the recursive
+ * updates can be detected with locational setups that rely on a specific block update
+ * order.
+ * 
+ * <p>
+ * What we can optimize, however, are the power calculations. In vanilla, these are split
+ * into two parts:
+ * <br>
+ * - Power from non-wire components.
+ * <br>
+ * - Power from other redstone wires.
+ * <br>
+ * We can combine the two to reduce calls to World.getBlockState and BlockState.isSolidBlock
+ * as well as calls to BlockState.getWeakRedstonePower and BlockState.getStrongRedstonePower.
+ * We can avoid calling those last two methods on redstone wires altogether, since we know
+ * they should return 0.
+ * <br>
+ * These changes can lead to a mspt reduction of up to 30% on top of Lithium's other
+ * performance improvements.
+ * 
  * @author Space Walker
  */
 @Mixin(RedstoneWireBlock.class)
 public class RedstoneWireBlockMixin extends Block {
-
+    
     private static final Direction[] DIRECTIONS = Direction.values();
     private static final Direction[] DIRECTIONS_VIRTICAL = { Direction.DOWN, Direction.UP };
     private static final Direction[] DIRECTIONS_HORIZONTAL = { Direction.WEST, Direction.EAST, Direction.NORTH, Direction.SOUTH };
-
-    private static final int MIN = 0;
-    private static final int MAX = 15;
-    private static final int MAX_WIRE = MAX - 1;
-
+    
+    private static final int MIN = 0;            // smallest possible power value
+    private static final int MAX = 15;           // largest possible power value
+    private static final int MAX_WIRE = MAX - 1; // largest possible power a wire can receive from another wire
+    
     public RedstoneWireBlockMixin(Settings settings) {
         super(settings);
     }
-
+    
     @Inject(
             method = "getReceivedRedstonePower",
             cancellable = true,
@@ -42,7 +77,11 @@ public class RedstoneWireBlockMixin extends Block {
         cir.setReturnValue(this.getReceivedPower(world, pos));
         cir.cancel();
     }
-
+    
+    /**
+     * Calculate the redstone power a wire at the given location receives from the
+     * blocks around it.
+     */
     private int getReceivedPower(World world, BlockPos pos) {
         int power = MIN;
         
@@ -54,6 +93,7 @@ public class RedstoneWireBlockMixin extends Block {
             }
         }
         
+        // In vanilla this check is done up to 4 times.
         BlockPos up = pos.up();
         boolean checkWiresAbove = world.getBlockState(up).isSolidBlock(world, up);
         
@@ -67,10 +107,18 @@ public class RedstoneWireBlockMixin extends Block {
         
         return power;
     }
-
+    
+    /**
+     * Calculate the redstone power a wire receives from a block above or below it.
+     * We do these positions separately because there are no wire connections
+     * vertically. This simplifies the calculations a little.
+     */
     private int getPowerFromVertical(World world, BlockPos pos, Direction toDir) {
         BlockState state = world.getBlockState(pos);
         
+        // Wires do not accept power from other wires directly above or below them,
+        // so those can be ignored. Similarly, if there is air directly above or
+        // below a wire, it does not receive any power from that direction.
         if (state.isOf(this) || state.isAir()) {
             return MIN;
         }
@@ -82,12 +130,15 @@ public class RedstoneWireBlockMixin extends Block {
         }
         
         if (state.isSolidBlock(world, pos)) {
-            return Math.max(power, this.getStrongPowerTo(world, pos, toDir));
+            return Math.max(power, this.getStrongPowerTo(world, pos, toDir.getOpposite()));
         }
         
         return power;
     }
-
+    
+    /**
+     * Calculate the redstone power a wire receives from blocks next to it.
+     */
     private int getPowerFromSide(World world, BlockPos pos, Direction toDir, boolean checkWiresAbove) {
         BlockState state = world.getBlockState(pos);
         
@@ -102,7 +153,7 @@ public class RedstoneWireBlockMixin extends Block {
         }
         
         if (state.isSolidBlock(world, pos)) {
-            power = Math.max(power, this.getStrongPowerTo(world, pos, toDir));
+            power = Math.max(power, this.getStrongPowerTo(world, pos, toDir.getOpposite()));
             
             if (power >= MAX) {
                 return MAX;
@@ -118,16 +169,19 @@ public class RedstoneWireBlockMixin extends Block {
             }
         } else if (power < MAX_WIRE) {
             BlockPos down = pos.down();
-            BlockState aboveState = world.getBlockState(down);
+            BlockState belowState = world.getBlockState(down);
             
-            if (aboveState.isOf(this)) {
-                power = Math.max(power, aboveState.get(Properties.POWER) - 1);
+            if (belowState.isOf(this)) {
+                power = Math.max(power, belowState.get(Properties.POWER) - 1);
             }
         }
         
         return power;
     }
-
+    
+    /**
+     * Calculate the strong power a block receives from the blocks around it.
+     */
     private int getStrongPowerTo(World world, BlockPos pos, Direction ignore) {
         int power = MIN;
         

--- a/src/main/resources/lithium.mixins.json
+++ b/src/main/resources/lithium.mixins.json
@@ -77,6 +77,7 @@
     "block.hopper.TypeFilterableListMixin",
     "block.moving_block_shapes.PistonBlockEntityMixin",
     "block.moving_block_shapes.VoxelShapeMixin",
+    "block.redstone_wire.RedstoneWireBlockMixin",
     "cached_hashcode.BlockNeighborGroupMixin",
     "chunk.block_counting.AbstractBlockStateMixin",
     "chunk.block_counting.ChunkSectionMixin",


### PR DESCRIPTION
These optimizations improve the calculations a redstone wire does to determine the redstone power it receives from the blocks around it. As per my testing they can lead to an mspt reduction of up to 30% for dust grids and up to 25% for dust lines, on top of Lithium's other optimizations.

These optimizations do not change how redstone dust updates the blocks around it, nor does it change the recursive way it updates. That means vanilla behavior is 100% preserved.