### PR TITLE
Do not write mismatched palette and data sizes to disk

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/chunk/serialization/PalettedContainerMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/chunk/serialization/PalettedContainerMixin.java
@@ -98,7 +98,7 @@ public abstract class PalettedContainerMixin<T> {
             ((CompactingPackedIntegerArray) this.data).compact(this.palette, compactedPalette, array);
 
             // If the palette didn't change during compaction, do a simple copy of the data array
-            if (palette != null && palette.getSize() == compactedPalette.getSize()) {
+            if (palette != null && palette.getSize() == compactedPalette.getSize() && this.paletteSize == Math.max(4, MathHelper.log2DeBruijn(palette.getSize()))) { // paletteSize can de-sync from palette - see https://github.com/CaffeineMC/lithium-fabric/issues/279
                 dataArray = this.data.getStorage().clone();
             } else {
                 // Re-pack the integer array as the palette has changed size


### PR DESCRIPTION
Mismatched sizes do not cause issues with the 1.17.1 deserializer.
However, in the early snapshots of 1.18 it will cause chunks
to error while loading, and thus cause regeneration of
these chunks.

The root cause of the de-sync between the paletteSize and
the actual palette inside PalettedContainer seems to be
caused by the logic inside PalettedContainer#onResize. The
new palette is not calculated from the old palette, but rather
is implicitly calculated by calling set() for all positions
using the old data and old palette. Thus, if a block that
once existed in the old palette no longer exists in the
current ChunkSection, it will not exist in the _new_
palette. This can cause the palette size to decrease
to a lower bitsize, _without_ causing the underlying
paletteSize to change.

The fix I have applied is to simply check if the paletteSize
and the actual underlying palette agree on the underlying
data storage size. If they don't, then simply branch to
the code that accounts for palette size change.

Fixes https://github.com/CaffeineMC/lithium-fabric/issues/279