### PR TITLE
Update remaining references of Java 16 to 17

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,11 +11,11 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Set up JDK 16
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: 16
+          java-version: 17
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Upload assets to CurseForge

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ projects. The basic overview is provided here for those familiar.
 
 #### Requirements
 
-- JDK 16
+- JDK 17
     - You can either install this through a package manager such as [Chocolatey](https://chocolatey.org/) on Windows
       or [SDKMAN!](https://sdkman.io/) on other platforms. If you'd prefer to not use a package manager, you can always
       grab the installers or packages directly from [AdoptOpenJDK](https://adoptopenjdk.net/).

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,5 @@
 before_install:
     - export SDKMAN_DIR="/home/jitpack/.sdkman/"
     - source "/home/jitpack/.sdkman/bin/sdkman-init.sh"
-    - sdk install java 16.0.1-open
-    - sdk use java 16.0.1-open
+    - sdk install java 17.0.1-open
+    - sdk use java 17.0.1-open


### PR DESCRIPTION
This fixes the JitPack build and should also fix the publish workflow.