### PR TITLE
Quiltflower decompilation support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,16 @@ import net.fabricmc.loom.task.RemapJarTask
 plugins {
     id 'fabric-loom' version '0.10-SNAPSHOT'
     id 'maven-publish'
+    id "io.github.juuxel.loom-quiltflower-mini" version "1.1.0"
 }
 
 loom {
     accessWidenerPath = file("src/main/resources/lithium.accesswidener")
     mixin.defaultRefmapName = "mixins.lithium.refmap.json"
+}
+
+quiltflower {
+    addToRuntimeClasspath.set(true)
 }
 
 apply plugin: 'fabric-loom'

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,10 @@ pluginManagement {
             url = 'https://maven.fabricmc.net/'
         }
         gradlePluginPortal()
+        maven {
+            name = "Cotton"
+            url = uri("https://server.bbkr.space/artifactory/libs-release/")
+        }
     }
 }
 


### PR DESCRIPTION
### Proposed Changes

Adds the gradle task `genSourcesWithQuiltflower` for generating Minecraft's sources.

Mirrors changes from https://github.com/CaffeineMC/sodium-fabric/pull/992 for Lithium
