### PR TITLE
fix: Make GH Actions consistent with Sodium's

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,26 +4,42 @@ on: [ push, pull_request ]
 
 jobs:
   build:
-      runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-      steps:
-          -   uses: actions/checkout@v2
-          -   name: Set up JDK 16
-              uses: actions/setup-java@v2
-              with:
-                  distribution: 'adopt'
-                  java-version: 16
-          -   name: Grant execute permission for gradlew
-              run: chmod +x gradlew
-          -   name: Build with Gradle
-              run: ./gradlew build
-
-          -   name: run test server
-              timeout-minutes: 5
-              run: ./gradlew runAutoTestServer
-
-          -   name: Upload build artifacts
-              uses: actions/upload-artifact@v1
-              with:
-                  name: build-artifacts
-                  path: build/libs
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 17
+      uses: actions/setup-java@v1
+      with:
+        java-version: 17
+    - name: Cache/Uncache Lithium
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/loom-cache
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+          
+    - name: Build artifacts
+      run: ./gradlew build
+    - name: Extract current branch name
+      shell: bash
+        
+      # bash pattern expansion to grab branch name without slashes
+      run: ref="${GITHUB_REF#refs/heads/}" && echo "::set-output name=branch::${ref////-}"
+      id: ref
+         
+      # Run Lithium test server
+    - name: run test server
+      timeout-minutes: 5
+      run: ./gradlew runAutoTestServer
+      
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: lithium-artifacts-${{ steps.ref.outputs.branch }}
+        # Filter built files to disregard -sources and -dev, and leave only the minecraft-compatible jars.
+        path: build/libs/*[0-9].jar


### PR DESCRIPTION
Noticed while updating to the latest dev builds of Lithium and Sodium that the artifacts produced were different, such as Sodium's naming for the build artifacts file being `sodium-artifacts-(branch name)` and only including the Minecraft compatible jar file.

Ideally, it feels like these should be pretty much the same between the three mods, and could make it easier to tell which file has which artifacts inside if you have a dozen files named `build-artifacts.zip` downloaded with no way to tell what they're for without checking inside them like I do.

This is my first PR, so I hope I'm doing this right