### PR TITLE
Allows 1.18.1 to work

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,7 +27,7 @@
     "accessWidener": "lithium.accesswidener",
     "depends": {
       "fabricloader": ">=0.10.5",
-      "minecraft": "1.18"
+      "minecraft": "1.18.x",
     },
     "breaks": {
         "optifabric": "*"


### PR DESCRIPTION
Currently the mod hardcodes to 1.18, which disallows 1.18.1 from loading. I see no reason the shouldn't working in 1.18.1