### PR TITLE
add an entrypoint in LithiumMixinPlugin postApply

### DIFF
--- a/src/api/java/me/jellysquid/mods/lithium/api/mixin/LithiumMixin.java
+++ b/src/api/java/me/jellysquid/mods/lithium/api/mixin/LithiumMixin.java
@@ -1,0 +1,8 @@
+package me.jellysquid.mods.lithium.api.mixin;
+
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+public interface LithiumMixin {
+    default void onLithiumMixinPostApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo){}
+}

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/LithiumMixinPlugin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/LithiumMixinPlugin.java
@@ -1,8 +1,10 @@
 package me.jellysquid.mods.lithium.mixin;
 
+import me.jellysquid.mods.lithium.api.mixin.LithiumMixin;
 import me.jellysquid.mods.lithium.common.LithiumMod;
 import me.jellysquid.mods.lithium.common.config.LithiumConfig;
 import me.jellysquid.mods.lithium.common.config.Option;
+import net.fabricmc.loader.api.FabricLoader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.objectweb.asm.tree.ClassNode;
@@ -95,6 +97,8 @@ public class LithiumMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
-
+        FabricLoader.getInstance().getEntrypoints("lithium-mixin-post-apply", LithiumMixin.class).forEach(
+                lm->lm.onLithiumMixinPostApply(targetClassName, targetClass, mixinClassName, mixinInfo)
+        );
     }
 }


### PR DESCRIPTION
- adds an interface `LithiumMixin` to the api with a default method `onLithiumMixinPostApply`
- calls a `lithium-mixin-post-apply` entrypoint in `LithiumMixinPlugin;postApply` which passes it's parameters using said interface

My usecase being fixing unascribed/fabrication#376 which requires the ability to toggle lithiums redstone optimizations at runtime sfort/fabrication@03c55af