### PR TITLE
Set the LockHelper field in PalettedContainer to null

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/chunk/no_locking/PalettedContainerMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/chunk/no_locking/PalettedContainerMixin.java
@@ -1,8 +1,15 @@
 package me.jellysquid.mods.lithium.mixin.chunk.no_locking;
 
+import net.minecraft.util.thread.LockHelper;
 import net.minecraft.world.chunk.PalettedContainer;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
  * The implementation of {@link PalettedContainer} performs a strange check to catch concurrent modification and throws
@@ -21,6 +28,23 @@ import org.spongepowered.asm.mixin.Overwrite;
  */
 @Mixin(PalettedContainer.class)
 public class PalettedContainerMixin {
+    @Shadow
+    @Final
+    @Mutable
+    private LockHelper lockHelper;
+
+    @Inject(
+            method = {
+                    "<init>(Lnet/minecraft/util/collection/IndexedIterable;Ljava/lang/Object;Lnet/minecraft/world/chunk/PalettedContainer$PaletteProvider;)V",
+                    "<init>(Lnet/minecraft/util/collection/IndexedIterable;Lnet/minecraft/world/chunk/PalettedContainer$PaletteProvider;Lnet/minecraft/world/chunk/PalettedContainer$Data;)V",
+                    "<init>(Lnet/minecraft/util/collection/IndexedIterable;Lnet/minecraft/world/chunk/PalettedContainer$PaletteProvider;Lnet/minecraft/world/chunk/PalettedContainer$DataProvider;Lnet/minecraft/util/collection/PaletteStorage;Ljava/util/List;)V",
+            },
+            at = @At("TAIL")
+    )
+    public void removeLockHelper(CallbackInfo ci) {
+        this.lockHelper = null;
+    }
+
     /**
      * @reason Do not check the container's lock
      * @author JellySquid


### PR DESCRIPTION
The `LockHelper` instances add up to 17 MB or so in singleplayer, and more on servers with many players. I've implemented a smaller, but still functional version in FerriteCore; which causes Mixin to log warnings since both lithium and FC are overwriting the same methods (malte0811/FerriteCore#61). The easiest solution would be for me to automatically disable my Mixin when lithium is installed; with this PR lithium's version is both faster and smaller than mine (as it just removes the race detection).