### PR TITLE
Update to minecraft 1.19.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@
 org.gradle.jvmargs=-Xmx2G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.19.1
-yarn_mappings=1.19.1+build.1
-loader_version=0.14.8
+minecraft_version=1.19.2
+yarn_mappings=1.19.2+build.1
+loader_version=0.14.9
 # Mod Properties
 mod_version=0.8.3
 maven_group=me.jellysquid.mods

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,7 +27,10 @@
     "accessWidener": "lithium.accesswidener",
     "depends": {
       "fabricloader": ">=0.12.11",
-      "minecraft": "1.19.1"
+      "minecraft": [
+        "1.19.1",
+        "1.19.2"
+      ]
     },
     "breaks": {
         "optifabric": "*"


### PR DESCRIPTION
Currently, branch `1.19.x/dev` is still on version 1.19.1. Since it is the default branch, it causes issues when people attempt to build the latest git commit.