### PR TITLE
fix: removes redundant ticket add when not needed

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/world/chunk_access/ServerChunkManagerMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/world/chunk_access/ServerChunkManagerMixin.java
@@ -149,7 +149,7 @@ public abstract class ServerChunkManagerMixin {
                 // The holder is absent and we weren't asked to create anything, so return null
                 return null;
             }
-        } else if (((ChunkHolderExtended) holder).updateLastAccessTime(this.time)) {
+        } else if (create && ((ChunkHolderExtended) holder).updateLastAccessTime(this.time)) {
             // Only create a new chunk ticket if one hasn't already been submitted this tick
             // This maintains vanilla behavior (preventing chunks from being immediately unloaded) while also
             // eliminating the cost of submitting a ticket for most chunk fetches


### PR DESCRIPTION
There is a missing check for `create` parameter in `ServerChunkManagerMixin#getChunkBlocking` and it does not match vanilla behavior as the ticket should be added only when explicitly requested. 
This PR fixes this issue. 

Additionally, guarding ticket add here also slightly decreases MSPT (452 to 443 with 101 players spread in radius 2048)
before: <https://spark.lucko.me/z8TuFzcT29>
after: <https://spark.lucko.me/3l2JcNRxAE>
