### PR TITLE
feat: optimized preloading chunks by removing streams

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/ai/poi/fast_portals/PointOfInterestStorageMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/ai/poi/fast_portals/PointOfInterestStorageMixin.java
@@ -55,12 +55,16 @@ public abstract class PointOfInterestStorageMixin extends SerializingRegionBased
 
     @Unique
     private void lithium$preloadChunkIfAnySubChunkContainsPOI(WorldView worldView, int x, int z, int minSubChunk, int maxSubChunk) {
+        var chunkPos = new ChunkPos(x, z);
+        var longChunkPos = chunkPos.toLong();
+
+        if (this.preloadedChunks.contains(longChunkPos)) return;
+
         for (int y = minSubChunk; y < maxSubChunk; y++) {
             var sectionPos = ChunkSectionPos.from(x, y, z);
             var section = this.get(sectionPos.asLong());
             if (section.map(PointOfInterestSet::isValid).orElse(false)) {
-                var chunk = sectionPos.toChunkPos();
-                if (this.preloadedChunks.add(chunk.toLong())) {
+                if (this.preloadedChunks.add(longChunkPos)) {
                     worldView.getChunk(x, z, ChunkStatus.EMPTY);
                 }
                 break;

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/ai/poi/fast_portals/PointOfInterestStorageMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/ai/poi/fast_portals/PointOfInterestStorageMixin.java
@@ -1,0 +1,70 @@
+package me.jellysquid.mods.lithium.mixin.ai.poi.fast_portals;
+
+import com.mojang.datafixers.DataFixer;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import net.minecraft.datafixer.DataFixTypes;
+import net.minecraft.registry.DynamicRegistryManager;
+import net.minecraft.util.CuboidBlockIterator;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.ChunkSectionPos;
+import net.minecraft.world.HeightLimitView;
+import net.minecraft.world.WorldView;
+import net.minecraft.world.chunk.ChunkStatus;
+import net.minecraft.world.poi.PointOfInterestSet;
+import net.minecraft.world.poi.PointOfInterestStorage;
+import net.minecraft.world.storage.SerializingRegionBasedStorage;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.nio.file.Path;
+
+@Mixin(PointOfInterestStorage.class)
+public abstract class PointOfInterestStorageMixin extends SerializingRegionBasedStorage<PointOfInterestSet> {
+
+    @Shadow
+    @Final
+    private LongSet preloadedChunks;
+
+    public PointOfInterestStorageMixin(
+            Path path, DataFixer dataFixer, boolean dsync,
+            DynamicRegistryManager registryManager, HeightLimitView world
+    ) {
+        super(
+            path, PointOfInterestSet::createCodec, PointOfInterestSet::new,
+            dataFixer, DataFixTypes.POI_CHUNK, dsync, registryManager, world
+        );
+    }
+
+    /**
+     * @author Crec0
+     * @reason Streams in this method cause unnecessary lag. Simply rewriting this to not use streams, we gain
+     * considerable performance. Noticeable when large amount of entities are traveling through nether portals.
+     */
+    @Overwrite
+    public void preloadChunks(WorldView worldView, BlockPos pos, int radius) {
+        var chunkPos = new ChunkPos(pos);
+        var chunkRadius = Math.floorDiv(radius, 16);
+        var maxHeight = this.world.getTopSectionCoord() - 1;
+        var minHeight = this.world.getBottomSectionCoord();
+
+        var cursor = new CuboidBlockIterator(
+            chunkPos.x - chunkRadius, minHeight, chunkPos.z - chunkRadius,
+            chunkPos.x + chunkRadius, maxHeight, chunkPos.z + chunkRadius
+        );
+
+        while (cursor.step()) {
+            var sectionPos = ChunkSectionPos.from(cursor.getX(), cursor.getY(), cursor.getZ());
+            var section = this.get(sectionPos.asLong());
+
+            if (section.map(PointOfInterestSet::isValid).orElse(false)) {
+                var chunk = sectionPos.toChunkPos();
+                if (this.preloadedChunks.add(chunk.toLong())) {
+                    worldView.getChunk(chunkPos.x, chunkPos.z, ChunkStatus.EMPTY);
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/lithium.accesswidener
+++ b/src/main/resources/lithium.accesswidener
@@ -35,3 +35,5 @@ accessible method net/minecraft/nbt/NbtCompound <init> (Ljava/util/Map;)V
 accessible class net/minecraft/world/border/WorldBorder$Area
 
 accessible method net/minecraft/entity/ai/pathing/LandPathNodeMaker getCommonNodeType (Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/entity/ai/pathing/PathNodeType;
+
+accessible method net/minecraft/world/poi/PointOfInterestSet isValid ()Z

--- a/src/main/resources/lithium.mixins.json
+++ b/src/main/resources/lithium.mixins.json
@@ -22,6 +22,7 @@
     "ai.poi.PointOfInterestStorageMixin",
     "ai.poi.PointOfInterestTypesMixin",
     "ai.poi.SerializingRegionBasedStorageMixin",
+    "ai.poi.fast_portals.PointOfInterestStorageMixin",
     "ai.poi.fast_portals.PortalForcerMixin",
     "ai.poi.tasks.HideInHomeTaskMixin",
     "ai.poi.tasks.RaiderEntityAttackHomeGoalMixin",


### PR DESCRIPTION
Overwrite chunk preloading method to not use streams. This gives a considerable server performance when large amount of entities are going through nether portals

### Theoretical test
Average mspt with with 1024 repeating command blocks spawning items that go through portals to other dimension

<table>
<tr>
 <td></td>
 <td>Overworld -> Nether</td>
 <td>Nether -> Overworld</td>
</tr>
<tr>
 <td>Without</td>
 <td>76</td>
 <td>425</td>
</tr>
<tr>
 <td>With</td>
 <td>62</td>
 <td>147</td>
</tr>
</table>

### Practical test
A stacking raid farm at 32mspt without optimization decreased to 24mspt with this optimization