### PR TITLE
change: use main worker executor for util.block_tracking

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/util/block_tracking/ChunkSectionMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/util/block_tracking/ChunkSectionMixin.java
@@ -6,6 +6,7 @@ import me.jellysquid.mods.lithium.common.block.BlockStateFlags;
 import me.jellysquid.mods.lithium.common.block.TrackedBlockStatePredicate;
 import net.minecraft.block.BlockState;
 import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.Util;
 import net.minecraft.world.chunk.ChunkSection;
 import net.minecraft.world.chunk.PalettedContainer;
 import org.spongepowered.asm.mixin.Final;
@@ -69,7 +70,7 @@ public abstract class ChunkSectionMixin implements BlockCountingSection {
 
         if (this.countsByFlagFuture == null) {
             PalettedContainer<BlockState> blockStateContainer = this.blockStateContainer;
-            this.countsByFlagFuture = CompletableFuture.supplyAsync(() -> calculateLithiumCounts(blockStateContainer));
+            this.countsByFlagFuture = CompletableFuture.supplyAsync(() -> calculateLithiumCounts(blockStateContainer), Util.getMainWorkerExecutor());
         }
         return false;
     }


### PR DESCRIPTION
### Proposed Changes

Changes the `CompletableFuture` used in `mixin.util.block_tracking` to run on the normal Mojang background executor instead of the common ForkJoinPool. Use of the latter can cause issues with mods as it does not have the correct context classloader set (due to being initialized before the modloader). An example of such an issue is https://github.com/Fuzss/puzzleslib/issues/41; there were many mods involved but the problem originated with Lithium running code on the common ForkJoinPool in the first place.
