### PR TITLE
Use order index instead of indexOf for item merging optimization

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/entity/item/ItemEntityCategorizingList.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/entity/item/ItemEntityCategorizingList.java
@@ -327,6 +327,7 @@ public class ItemEntityCategorizingList extends AbstractList<ItemEntity> {
             for (ItemEntity itemEntity : this.delegate) {
                 this.updateStackSubscriptionOnAdd(itemEntity);
                 this.addToGroups(itemEntity);
+                this.setOrderIndex(itemEntity);
             }
         }
 
@@ -355,7 +356,6 @@ public class ItemEntityCategorizingList extends AbstractList<ItemEntity> {
             if (count * 2 <= maxCount) { //<=50% full
                 this.selfMergeableList.add(itemEntity);
             }
-            this.setOrderIndex(itemEntity);
         }
 
         private void removeFromGroups(ItemEntity itemEntity) {
@@ -480,6 +480,7 @@ public class ItemEntityCategorizingList extends AbstractList<ItemEntity> {
         public boolean add(ItemEntity itemEntity) {
             this.updateStackSubscriptionOnAdd(itemEntity);
             this.addToGroups(itemEntity);
+            this.setOrderIndex(itemEntity);
             return this.delegate.add(itemEntity);
         }
 

--- a/src/main/java/me/jellysquid/mods/lithium/common/entity/item/ItemEntityOrderInternalAccess.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/entity/item/ItemEntityOrderInternalAccess.java
@@ -1,0 +1,6 @@
+package me.jellysquid.mods.lithium.common.entity.item;
+
+public interface ItemEntityOrderInternalAccess {
+    long lithium$getOrderIndex();
+    void lithium$setOrderIndex(long orderIndex);
+}

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/entity/item_entity_stacking/ItemEntityMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/entity/item_entity_stacking/ItemEntityMixin.java
@@ -1,5 +1,6 @@
 package me.jellysquid.mods.lithium.mixin.entity.item_entity_stacking;
 
+import me.jellysquid.mods.lithium.common.entity.item.ItemEntityOrderInternalAccess;
 import me.jellysquid.mods.lithium.common.hopper.NotifyingItemStack;
 import me.jellysquid.mods.lithium.common.world.WorldHelper;
 import me.jellysquid.mods.lithium.mixin.util.accessors.ItemStackAccessor;
@@ -22,13 +23,25 @@ import java.util.List;
 import java.util.function.Predicate;
 
 @Mixin(ItemEntity.class)
-public abstract class ItemEntityMixin extends Entity {
+public abstract class ItemEntityMixin extends Entity implements ItemEntityOrderInternalAccess {
+    private long internalOrderIndex;
+
     public ItemEntityMixin(EntityType<?> type, World world) {
         super(type, world);
     }
 
     @Shadow
     public abstract ItemStack getStack();
+
+    @Override
+    public long lithium$getOrderIndex() {
+        return internalOrderIndex;
+    }
+    
+    @Override
+    public void lithium$setOrderIndex(long orderIndex) {
+        internalOrderIndex = orderIndex;
+    }
 
     @Redirect(
             method = "tryMerge()V",

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/entity/item_entity_stacking/ItemEntityMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/entity/item_entity_stacking/ItemEntityMixin.java
@@ -16,6 +16,7 @@ import net.minecraft.world.World;
 import net.minecraft.world.entity.SectionedEntityCache;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
@@ -24,6 +25,8 @@ import java.util.function.Predicate;
 
 @Mixin(ItemEntity.class)
 public abstract class ItemEntityMixin extends Entity implements ItemEntityOrderInternalAccess {
+
+    @Unique
     private long internalOrderIndex;
 
     public ItemEntityMixin(EntityType<?> type, World world) {


### PR DESCRIPTION
# What it does
Uses a pre-stored order index to insert item entities into the right group at the right location. O(n log n) -> O(log n). Important for keeping hopper operations optimized.

## Notes
- Order index is only set upon insertion into `SizeBucketedItemEntityList`
- I know @2No2Name doesn't like storing a seperate index because of issues in keeping it up to date, but this index is only updated once on insertion and improves time complexity for an important component.
- The order index is stored as a `long`
- I've noticed that you duplicated some code in `handleItemEntityStackReplacement`, since it looked like a mistake, I removed it.