### PR TITLE
fix: throw EntryMissingException for null entries in hash palette

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/world/chunk/LithiumHashPalette.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/world/chunk/LithiumHashPalette.java
@@ -7,6 +7,7 @@ import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.encoding.VarInts;
 import net.minecraft.util.collection.IndexedIterable;
+import net.minecraft.world.chunk.EntryMissingException;
 import net.minecraft.world.chunk.Palette;
 import net.minecraft.world.chunk.PaletteResizeListener;
 
@@ -120,11 +121,16 @@ public class LithiumHashPalette<T> implements Palette<T> {
     public T get(int id) {
         T[] entries = this.entries;
 
+        T entry = null;
         if (id >= 0 && id < entries.length) {
-            return entries[id];
+            entry = entries[id];
         }
 
-        return null;
+        if (entry != null) {
+            return entry;
+        } else {
+            throw new EntryMissingException(id);
+        }
     }
 
     @Override


### PR DESCRIPTION
At some point (I believe it was 1.17 or 1.18), vanilla changed the default palettes used by PalettedContainers (including `BiMapPalette`) to throw `EntryMissingException` if the entry for the desired ID is null. This PR adjusts Lithium to do the same.