### PR TITLE
Add `lithium$trackBlockStateChange` method to `BlockCountingSection`

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/block/BlockCountingSection.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/block/BlockCountingSection.java
@@ -1,5 +1,9 @@
 package me.jellysquid.mods.lithium.common.block;
 
+import net.minecraft.block.BlockState;
+
 public interface BlockCountingSection {
     boolean mayContainAny(TrackedBlockStatePredicate trackedBlockStatePredicate);
+
+    void lithium$trackBlockStateChange(BlockState newState, BlockState oldState);
 }

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/util/block_tracking/ChunkSectionMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/util/block_tracking/ChunkSectionMixin.java
@@ -30,6 +30,7 @@ public abstract class ChunkSectionMixin implements BlockCountingSection, BlockLi
     @Shadow
     @Final
     private PalettedContainer<BlockState> blockStateContainer;
+
     @Unique
     private short[] countsByFlag = null;
     private ChunkSectionChangeCallback changeListener;
@@ -102,6 +103,11 @@ public abstract class ChunkSectionMixin implements BlockCountingSection, BlockLi
             locals = LocalCapture.CAPTURE_FAILHARD
     )
     private void updateFlagCounters(int x, int y, int z, BlockState newState, boolean lock, CallbackInfoReturnable<BlockState> cir, BlockState oldState) {
+        this.lithium$trackBlockStateChange(newState, oldState);
+    }
+
+    @Override
+    public void lithium$trackBlockStateChange(BlockState newState, BlockState oldState) {
         short[] countsByFlag = this.countsByFlag;
         if (countsByFlag == null) {
             return;


### PR DESCRIPTION
This allows other mods such as Noisium and Big Globe to call this function using the `BlockCountingSection` interface to track blockstates (increment/decrement the blockstate counter) during world generation, for example.

Example usage (lets Lithium know that a blockstate has changed from air to stone):
```java
((BlockCountingSection) chunkSection).lithium$trackBlockStateChange(Blocks.STONE.getDefaultState(), BlockState.AIR)
```

Closes #506.