### PR TITLE
Fix hashed reference lists being created unnecessarily

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/collections/mob_spawning/PoolMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/collections/mob_spawning/PoolMixin.java
@@ -25,7 +25,7 @@ public class PoolMixin<E extends Weighted> {
     @Inject(method = "<init>(Ljava/util/List;)V", at = @At("RETURN"))
     private void init(List<? extends E> entries, CallbackInfo ci) {
         //We are using reference equality here, because all vanilla implementations of Weighted use reference equality
-        this.entryHashList = this.entries.size() > 4 ? this.entries : Collections.unmodifiableList(new HashedReferenceList<>(this.entries));
+        this.entryHashList = this.entries.size() < 4 ? this.entries : Collections.unmodifiableList(new HashedReferenceList<>(this.entries));
     }
 
     /**


### PR DESCRIPTION
The original logic creates a `HashedReferenceList` when the list is very small (which is when the optimization would have least impact). This generates a lot of allocations when creating tiny `Pool`s and also seems unintended. Now, the hashed implementation is used for large Pools (where it is likely to improve performance), and the list is used as-is if small enough.