### PR TITLE
fix: use dimension type from constructor instead of calling `getDimension`

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/world/inline_height/WorldMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/world/inline_height/WorldMixin.java
@@ -9,7 +9,6 @@ import net.minecraft.world.MutableWorldProperties;
 import net.minecraft.world.World;
 import net.minecraft.world.dimension.DimensionType;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -21,9 +20,6 @@ import java.util.function.Supplier;
  */
 @Mixin(World.class)
 public abstract class WorldMixin implements HeightLimitView {
-    @Shadow
-    public abstract DimensionType getDimension();
-
     private int bottomY;
     private int height;
     private int topYInclusive;
@@ -32,9 +28,9 @@ public abstract class WorldMixin implements HeightLimitView {
             method = "<init>",
             at = @At("RETURN")
     )
-    private void initHeightCache(MutableWorldProperties properties, RegistryKey<?> registryRef, DynamicRegistryManager registryManager, RegistryEntry<?> dimensionEntry, Supplier<?> profiler, boolean isClient, boolean debugWorld, long biomeAccess, int maxChainedNeighborUpdates, CallbackInfo ci) {
-        this.height = this.getDimension().height();
-        this.bottomY = this.getDimension().minY();
+    private void initHeightCache(MutableWorldProperties properties, RegistryKey<?> registryRef, DynamicRegistryManager registryManager, RegistryEntry<DimensionType> dimensionEntry, Supplier<?> profiler, boolean isClient, boolean debugWorld, long biomeAccess, int maxChainedNeighborUpdates, CallbackInfo ci) {
+        this.height = dimensionEntry.value().height();
+        this.bottomY = dimensionEntry.value().minY();
         this.topYInclusive = this.bottomY + this.height - 1;
     }
 


### PR DESCRIPTION
We ran into a mod compat issue from a mod overriding `getDimension` in its own `World` subclass and returning a value from a field it initialized in the subclass constructor. Since Lithium's inject runs before the subclass constructor, this caused an NPE.

The best solution IMO is to just use the dimension type provided as the constructor argument, rather than retrieving it through `getDimension`. This changes nothing for vanilla behavior because the default implementation of `World#getDimension()` returns a field initialized by that argument.