### PR TITLE
Fix incompatability with scarpet explosion event

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/world/explosions/cache_exposure/ExplosionMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/world/explosions/cache_exposure/ExplosionMixin.java
@@ -1,5 +1,7 @@
 package me.jellysquid.mods.lithium.mixin.world.explosions.cache_exposure;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import me.jellysquid.mods.lithium.common.world.ExplosionCache;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.math.Vec3d;
@@ -7,7 +9,6 @@ import net.minecraft.world.explosion.Explosion;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 /**
  * Optimizations for Explosions: Remove duplicate {@link Explosion#getExposure(Vec3d, Entity)} calls.
@@ -24,8 +25,8 @@ public abstract class ExplosionMixin implements ExplosionCache {
         this.cachedEntity = entity;
     }
 
-    @Redirect(method = "collectBlocksAndDamageEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/explosion/Explosion;getExposure(Lnet/minecraft/util/math/Vec3d;Lnet/minecraft/entity/Entity;)F"))
-    private float returnCachedExposure(Vec3d source, Entity entity) {
-        return this.cachedEntity == entity ? this.cachedExposure : Explosion.getExposure(source, entity);
+    @WrapOperation(method = "collectBlocksAndDamageEntities", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/explosion/Explosion;getExposure(Lnet/minecraft/util/math/Vec3d;Lnet/minecraft/entity/Entity;)F"))
+    private float returnCachedExposure(Vec3d source, Entity entity, Operation<Float> original) {
+        return this.cachedEntity == entity ? this.cachedExposure : original.call(source, entity);
     }
 }


### PR DESCRIPTION
Since https://github.com/gnembon/fabric-carpet/pull/1937 didn't get merged for a while, here is a tricy ways of fixing the incompatability in lithium's side.

Just simply replace the `@Redirect` into `@WrapOperation`, and the `original.call()` would contain the `@Redirect` from fabric-carpet. Therefore the `getExplosure()` firstly goes to our wrapping, then scarpet would detect the explosion event. But if it is a duplucated explosure we would skip it, and actually from the design of scarpet it is useless to detect the explosion again (as they are the same one, just mentioned again).

Tested in 1.21 with `fabric-carpet`, the wrapping works and the explosion event is triggered too.