### PR TITLE
Fix crash with betterchunkloading mod

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/mixin/minimal_nonvanilla/world/expiring_chunk_tickets/ChunkTicketManagerMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/minimal_nonvanilla/world/expiring_chunk_tickets/ChunkTicketManagerMixin.java
@@ -72,7 +72,7 @@ public abstract class ChunkTicketManagerMixin {
     private void unregisterExpiringTicket(long pos, ChunkTicket<?> ticket, CallbackInfo ci) {
         if (canExpire(ticket)) {
             SortedArraySet<ChunkTicket<?>> ticketsAtPos = this.positionWithExpiringTicket.get(pos);
-            if (canNoneExpire(ticketsAtPos)) {
+            if (ticketsAtPos != null && canNoneExpire(ticketsAtPos)) {
                 this.positionWithExpiringTicket.remove(pos);
             }
         }


### PR DESCRIPTION
There is a issue involving Betterchunkloading mod that causes the server to crash when a player moves enough to unload chunks.
``this.positionWithExpiringTicket.get(pos)`` are presumed to never be null but rather a list that could be empty. More debugging is needed in order to find the reason why this would ever return a null value, which is probably Betterchunkloading's fault, regardless, this check will prevent the server from crashing on a situation like this.