### PR TITLE
[1.21.1] Fix crash with level wrappers

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/lithium/common/world/LithiumData.java
+++ b/common/src/main/java/net/caffeinemc/mods/lithium/common/world/LithiumData.java
@@ -6,6 +6,7 @@ import net.caffeinemc.mods.lithium.common.tracking.block.ChunkSectionChangeCallb
 import net.caffeinemc.mods.lithium.common.tracking.block.SectionedBlockChangeTracker;
 import net.caffeinemc.mods.lithium.common.tracking.entity.SectionedEntityMovementTracker;
 import net.caffeinemc.mods.lithium.common.util.deduplication.LithiumInterner;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.entity.ai.navigation.PathNavigation;
@@ -35,10 +36,10 @@ public interface LithiumData {
             // Block ChunkSection listeners
             Long2ReferenceOpenHashMap<ChunkSectionChangeCallback> chunkSectionChangeCallbacks
     ) {
-        public Data(Level world) {
+        public Data(HolderLookup.Provider registries) {
             this(
                     new GameEventDispatcherStorage(),
-                    Objects.requireNonNullElse(world.registryAccess(), RegistryAccess.EMPTY).lookup(Registries.BANNER_PATTERN).map(Raid::getLeaderBannerInstance).orElse(null),
+                    Objects.requireNonNullElse(registries, RegistryAccess.EMPTY).lookup(Registries.BANNER_PATTERN).map(Raid::getLeaderBannerInstance).orElse(null),
                     new ReferenceOpenHashSet<>(),
                     new LithiumInterner<>(),
                     new LithiumInterner<>(),

--- a/common/src/main/java/net/caffeinemc/mods/lithium/mixin/util/data_storage/LevelMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/lithium/mixin/util/data_storage/LevelMixin.java
@@ -22,7 +22,7 @@ public class LevelMixin implements LithiumData {
 
     @Inject(method = "<init>", at = @At("RETURN"))
     private void initLithiumData(WritableLevelData properties, ResourceKey<?> registryRef, RegistryAccess registryManager, Holder<?> dimensionEntry, Supplier<?> profiler, boolean isClient, boolean debugWorld, long biomeAccess, int maxChainedNeighborUpdates, CallbackInfo ci) {
-        this.storage = new Data((Level) (Object) this);
+        this.storage = new Data(registryManager);
     }
 
     @Override


### PR DESCRIPTION
- Use the passed RegistryAccess instead of retrieving it from the level ourselves, this fixes an issue with mods like create that wrap levels, as this mixin injects into the super call, and they set the level after the super call, which results in their stored/wrapped level being null when Level#registryAccess is called

Backport of https://github.com/CaffeineMC/lithium/pull/616