### PR TITLE
Fix multipart entities (dragon parts, modded part entities) missing from movement collision checks, matching vanilla Level.getEntities (fixes #651)

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/lithium/common/services/PlatformEntityAccess.java
+++ b/common/src/main/java/net/caffeinemc/mods/lithium/common/services/PlatformEntityAccess.java
@@ -3,6 +3,7 @@ package net.caffeinemc.mods.lithium.common.services;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.function.Predicate;
@@ -10,6 +11,6 @@ import java.util.function.Predicate;
 public interface PlatformEntityAccess {
     PlatformEntityAccess INSTANCE = Services.load(PlatformEntityAccess.class);
 
-    void addEnderDragonParts(Level level, Entity excludedEntity, AABB box, Predicate<? super Entity> entityFilter, ArrayList<Entity> entities);
+    void addEnderDragonParts(Level level, Entity excludedEntity, AABB box, @Nullable Predicate<? super Entity> entityFilter, ArrayList<Entity> entities);
 
 }

--- a/common/src/main/java/net/caffeinemc/mods/lithium/common/world/WorldHelper.java
+++ b/common/src/main/java/net/caffeinemc/mods/lithium/common/world/WorldHelper.java
@@ -46,7 +46,9 @@ public class WorldHelper {
             EntitySectionStorage<Entity> cache = getEntityCacheOrNull(world);
             if (cache != null) {
                 Profiler.get().incrementCounter("getEntities");
-                return getEntitiesOfEntityGroupWithoutDragonPieces(cache, collidingEntity, EntityClassGroup.NoDragonClassGroup.BOAT_SHULKER_LIKE_COLLISION, box, null);
+                //Include dragon parts and other multipart entity pieces like vanilla's Level.getEntities does.
+                //Vanilla dragon parts do not pass the collision predicates, but modded parts may (e.g. multipart shield entities).
+                return getEntitiesOfEntityGroupPlusDragonPieces(world, cache, collidingEntity, EntityClassGroup.NoDragonClassGroup.BOAT_SHULKER_LIKE_COLLISION, box, null);
             }
         }
         //use vanilla code in case the shortcut is not applicable
@@ -60,7 +62,8 @@ public class WorldHelper {
                 EntitySectionStorage<Entity> cache = getEntityCacheOrNull(world);
                 if (cache != null) {
                     Profiler.get().incrementCounter("getEntities");
-                    return getEntitiesOfEntityGroupWithoutDragonPieces(cache, collidingEntity, EntityClassGroup.NoDragonClassGroup.BOAT_SHULKER_LIKE_COLLISION, box, entityFilter);
+                    //Include dragon parts and other multipart entity pieces like vanilla's Level.getEntities does.
+                    return getEntitiesOfEntityGroupPlusDragonPieces(world, cache, collidingEntity, EntityClassGroup.NoDragonClassGroup.BOAT_SHULKER_LIKE_COLLISION, box, entityFilter);
                 }
             }
         }

--- a/fabric/src/main/java/net/caffeinemc/mods/lithium/fabric/FabricEntityAccess.java
+++ b/fabric/src/main/java/net/caffeinemc/mods/lithium/fabric/FabricEntityAccess.java
@@ -17,7 +17,7 @@ public class FabricEntityAccess implements PlatformEntityAccess {
         for (EnderDragonPart enderDragonPart : level.dragonParts()) {
             if (enderDragonPart != excludedEntity
                     && enderDragonPart.parentMob != excludedEntity
-                    && entityFilter.test(enderDragonPart) &&
+                    && (entityFilter == null || entityFilter.test(enderDragonPart)) &&
                     box.intersects(enderDragonPart.getBoundingBox())
             ) {
                 entities.add(enderDragonPart);

--- a/neoforge/src/main/java/net/caffeinemc/mods/lithium/neoforge/NeoForgeEntityAccess.java
+++ b/neoforge/src/main/java/net/caffeinemc/mods/lithium/neoforge/NeoForgeEntityAccess.java
@@ -17,7 +17,7 @@ public class NeoForgeEntityAccess implements PlatformEntityAccess {
         for (PartEntity<?> partEntity : level.dragonParts()) {
             if (partEntity != excludedEntity
                     && partEntity.getParent() != excludedEntity
-                    && entityFilter.test(partEntity)
+                    && (entityFilter == null || entityFilter.test(partEntity))
                     && box.intersects(partEntity.getBoundingBox())
             ) {
                 entities.add(partEntity);


### PR DESCRIPTION
While looking into entity collisions, I found that Lithium's optimized movement collision path wasn't checking multipart entity pieces like ender dragon parts.

Vanilla's `Level.getEntities` always includes these parts, but Lithium's movement collision code only queried entities stored in the section storage. Lithium already has a lookup that includes multipart entities (`getEntitiesOfEntityGroupPlusDragonPieces`), but it was only being used for projectile collisions.

This meant that collidable multipart entities from mods, such as the shields in Iron's Spells 'n Spellbooks (see #651), had no collision when Lithium's entity collision optimization was enabled because their part entities were never returned.

This change updates both movement collision paths to use the multipart-aware lookup and makes `entityFilter` nullable, since movement collisions don't pass one anyway. Vanilla behavior is unchanged, since vanilla dragon parts don't override `canBeCollidedWith`.

Fixes #651