### PR TITLE
Optimize jigsaw free space tracking with cuboid difference shapes

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/lithium/common/shapes/VoxelShapeCuboidDifference.java
+++ b/common/src/main/java/net/caffeinemc/mods/lithium/common/shapes/VoxelShapeCuboidDifference.java
@@ -1,0 +1,495 @@
+package net.caffeinemc.mods.lithium.common.shapes;
+
+import com.mojang.math.OctahedralGroup;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import it.unimi.dsi.fastutil.doubles.DoubleList;
+import net.minecraft.core.AxisCycle;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.world.phys.shapes.BooleanOp;
+import net.minecraft.world.phys.shapes.DiscreteVoxelShape;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A {@link VoxelShape} that represents a cuboid minus a list of cuboids without storing any voxels. It is used to
+ * replace the very expensive incremental {@link Shapes#joinUnoptimized} / {@link Shapes#joinIsNotEmpty} calls jigsaw
+ * structure placement uses to track the remaining free space (structure bounds minus already placed pieces).
+ * <p>
+ * Instead of merging coordinate lists and joining voxel sets, subtracting a placed piece just appends 6 doubles to a
+ * list, and testing whether a candidate piece exceeds the free space is a linear scan over the subtracted cuboids
+ * using exact double comparisons.
+ * <p>
+ * Exactness: All coordinates handled by the fast paths are required to be aligned to a 0.25 grid (jigsaw placement
+ * only produces integer coordinates and integer coordinates deflated by 0.25). Distinct coordinates on this grid
+ * differ by at least 0.25, so vanilla's 1e-7 epsilon coordinate merging in
+ * {@link net.minecraft.world.phys.shapes.IndirectMerger} never merges distinct coordinates and never produces cells
+ * with a volume close to 0. Therefore vanilla's voxel-based join results are exactly the results of unrounded box
+ * arithmetic, which this class implements. Inputs that are not grid aligned are rejected by the factory methods and
+ * the fast path queries, in which case callers fall back to vanilla behavior on the {@link #materialized()} shape.
+ * <p>
+ * Vanilla parity of the shape itself: Any {@link VoxelShape} method invoked on this shape delegates to
+ * {@link #materialized()}, which lazily computes the exact shape vanilla would have built by replaying the skipped
+ * {@link Shapes#create(AABB)} and {@link Shapes#joinUnoptimized} calls. The {@link DiscreteVoxelShape} of this shape
+ * delegates in the same way, so even code that directly accesses the {@link VoxelShape#shape} field behaves as if
+ * the vanilla shape was stored here.
+ */
+public class VoxelShapeCuboidDifference extends VoxelShape {
+    /**
+     * Maximum number of cuboids extracted when converting an unknown free space shape in
+     * {@link #tryConvert(VoxelShape)}. Vanilla's initial jigsaw free space converts to a single cuboid. The limit only
+     * exists to avoid degrading modded shapes with many cuboids into slow linear scans.
+     */
+    private static final int MAX_CONVERTED_CUBOIDS = 64;
+
+    /**
+     * Return values of {@link #exceedsFreeSpace(VoxelShape)}.
+     */
+    public static final int FALLBACK = -1;
+    public static final int CONTAINED = 0;
+    public static final int EXCEEDS = 1;
+
+    /**
+     * The shape this instance was converted from, used as the starting point when replaying the subtractions in
+     * {@link #materialized()}. If null, the starting point is {@link Shapes#create(AABB)} of the container cuboid,
+     * exactly like the call this shape was created in place of.
+     */
+    @Nullable
+    private final VoxelShape initialShape;
+
+    private final double minX, minY, minZ, maxX, maxY, maxZ;
+
+    /**
+     * The subtracted cuboids, 6 doubles (minX, minY, minZ, maxX, maxY, maxZ) per cuboid. The list is shared between
+     * instances created by {@link #subtract}: an instance only reads the first {@link #cuboidCount} * 6 entries and
+     * appends in place when it is the instance the list was last appended for.
+     */
+    private final DoubleArrayList cuboids;
+
+    /**
+     * Number of leading cuboids that describe the difference between the container cuboid and {@link #initialShape}.
+     * These only exist for containment queries and must not be replayed in {@link #materialized()}.
+     */
+    private final int initialCuboidCount;
+    private final int cuboidCount;
+
+    @Nullable
+    private VoxelShape materialized;
+
+    private VoxelShapeCuboidDifference(MaterializingDiscreteVoxelShape voxels, @Nullable VoxelShape initialShape,
+                                       double minX, double minY, double minZ, double maxX, double maxY, double maxZ,
+                                       DoubleArrayList cuboids, int initialCuboidCount, int cuboidCount) {
+        super(voxels);
+        voxels.owner = this;
+        this.initialShape = initialShape;
+        this.minX = minX;
+        this.minY = minY;
+        this.minZ = minZ;
+        this.maxX = maxX;
+        this.maxY = maxY;
+        this.maxZ = maxZ;
+        this.cuboids = cuboids;
+        this.initialCuboidCount = initialCuboidCount;
+        this.cuboidCount = cuboidCount;
+    }
+
+    /**
+     * Creates a free space shape equivalent to {@link Shapes#create(AABB)} of the given cuboid, or null if the
+     * coordinates are not grid aligned.
+     */
+    @Nullable
+    public static VoxelShapeCuboidDifference tryCreate(AABB cuboid) {
+        if (!isAligned(cuboid.minX, cuboid.minY, cuboid.minZ, cuboid.maxX, cuboid.maxY, cuboid.maxZ)) {
+            return null;
+        }
+        return new VoxelShapeCuboidDifference(new MaterializingDiscreteVoxelShape(), null,
+                cuboid.minX, cuboid.minY, cuboid.minZ, cuboid.maxX, cuboid.maxY, cuboid.maxZ,
+                new DoubleArrayList(), 0, 0);
+    }
+
+    /**
+     * Converts an existing free space shape into the cuboid difference representation by computing the difference
+     * between the shape's bounding box and the shape. Returns the given shape unchanged if it cannot be represented
+     * exactly, in which case all queries keep using vanilla code.
+     */
+    public static VoxelShape tryConvert(VoxelShape freeSpace) {
+        if (freeSpace instanceof VoxelShapeCuboidDifference || freeSpace.isEmpty() || !isAligned(freeSpace)) {
+            return freeSpace;
+        }
+        AABB bounds = freeSpace.bounds();
+        VoxelShape complement = Shapes.joinUnoptimized(Shapes.create(bounds), freeSpace, BooleanOp.ONLY_FIRST);
+        List<AABB> complementCuboids = complement.toAabbs();
+        if (complementCuboids.size() > MAX_CONVERTED_CUBOIDS) {
+            return freeSpace;
+        }
+        DoubleArrayList cuboids = new DoubleArrayList(complementCuboids.size() * 6);
+        for (AABB cuboid : complementCuboids) {
+            cuboids.add(cuboid.minX);
+            cuboids.add(cuboid.minY);
+            cuboids.add(cuboid.minZ);
+            cuboids.add(cuboid.maxX);
+            cuboids.add(cuboid.maxY);
+            cuboids.add(cuboid.maxZ);
+        }
+        return new VoxelShapeCuboidDifference(new MaterializingDiscreteVoxelShape(), freeSpace,
+                bounds.minX, bounds.minY, bounds.minZ, bounds.maxX, bounds.maxY, bounds.maxZ,
+                cuboids, complementCuboids.size(), complementCuboids.size());
+    }
+
+    /**
+     * Returns the vanilla shape to use when a call site cannot take a fast path. This must be used instead of passing
+     * this shape to vanilla shape operations directly.
+     */
+    public static VoxelShape unwrap(VoxelShape shape) {
+        if (shape instanceof VoxelShapeCuboidDifference cuboidDifference) {
+            return cuboidDifference.materialized();
+        }
+        return shape;
+    }
+
+    /**
+     * Fast path for {@code Shapes.joinIsNotEmpty(this, cuboid, BooleanOp.ONLY_SECOND)}: whether any part of the given
+     * cuboid shape lies outside this free space.
+     *
+     * @return {@link #EXCEEDS} if the cuboid exceeds the free space, {@link #CONTAINED} if not, {@link #FALLBACK} if
+     * the query cannot be answered exactly and the caller must fall back to vanilla behavior using
+     * {@link #unwrap(VoxelShape)}
+     */
+    public int exceedsFreeSpace(VoxelShape cuboid) {
+        DoubleList xCoords = cuboid.getCoords(Direction.Axis.X);
+        DoubleList yCoords = cuboid.getCoords(Direction.Axis.Y);
+        DoubleList zCoords = cuboid.getCoords(Direction.Axis.Z);
+        if (xCoords.size() != 2 || yCoords.size() != 2 || zCoords.size() != 2 || cuboid.isEmpty()) {
+            return FALLBACK;
+        }
+        double minX = xCoords.getDouble(0);
+        double minY = yCoords.getDouble(0);
+        double minZ = zCoords.getDouble(0);
+        double maxX = xCoords.getDouble(1);
+        double maxY = yCoords.getDouble(1);
+        double maxZ = zCoords.getDouble(1);
+        if (!(minX < maxX) || !(minY < maxY) || !(minZ < maxZ) || !isAligned(minX, minY, minZ, maxX, maxY, maxZ)) {
+            return FALLBACK;
+        }
+        return this.fullyContains(minX, minY, minZ, maxX, maxY, maxZ) ? CONTAINED : EXCEEDS;
+    }
+
+    /**
+     * Fast path for {@code Shapes.joinUnoptimized(this, cuboid, BooleanOp.ONLY_FIRST)}: the free space minus the
+     * given cuboid shape.
+     *
+     * @return the new free space shape, or null if the caller must fall back to vanilla behavior using
+     * {@link #unwrap(VoxelShape)}
+     */
+    @Nullable
+    public VoxelShape trySubtract(VoxelShape cuboid) {
+        DoubleList xCoords = cuboid.getCoords(Direction.Axis.X);
+        DoubleList yCoords = cuboid.getCoords(Direction.Axis.Y);
+        DoubleList zCoords = cuboid.getCoords(Direction.Axis.Z);
+        if (xCoords.size() != 2 || yCoords.size() != 2 || zCoords.size() != 2 || cuboid.isEmpty()) {
+            return null;
+        }
+        double minX = xCoords.getDouble(0);
+        double minY = yCoords.getDouble(0);
+        double minZ = zCoords.getDouble(0);
+        double maxX = xCoords.getDouble(1);
+        double maxY = yCoords.getDouble(1);
+        double maxZ = zCoords.getDouble(1);
+        if (!(minX < maxX) || !(minY < maxY) || !(minZ < maxZ) || !isAligned(minX, minY, minZ, maxX, maxY, maxZ)) {
+            return null;
+        }
+        return this.subtract(minX, minY, minZ, maxX, maxY, maxZ);
+    }
+
+    private boolean fullyContains(double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+        if (minX < this.minX || minY < this.minY || minZ < this.minZ ||
+                maxX > this.maxX || maxY > this.maxY || maxZ > this.maxZ) {
+            return false;
+        }
+        double[] cuboids = this.cuboids.elements();
+        for (int i = 0, end = this.cuboidCount * 6; i < end; i += 6) {
+            if (minX < cuboids[i + 3] && cuboids[i] < maxX &&
+                    minY < cuboids[i + 4] && cuboids[i + 1] < maxY &&
+                    minZ < cuboids[i + 5] && cuboids[i + 2] < maxZ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private VoxelShapeCuboidDifference subtract(double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+        DoubleArrayList cuboids = this.cuboids;
+        int numEntries = this.cuboidCount * 6;
+        if (cuboids.size() != numEntries) {
+            //the list was already appended for another instance, diverge with a copy
+            DoubleArrayList copy = new DoubleArrayList(numEntries + 6);
+            copy.addElements(0, cuboids.elements(), 0, numEntries);
+            cuboids = copy;
+        }
+        cuboids.add(minX);
+        cuboids.add(minY);
+        cuboids.add(minZ);
+        cuboids.add(maxX);
+        cuboids.add(maxY);
+        cuboids.add(maxZ);
+        return new VoxelShapeCuboidDifference(new MaterializingDiscreteVoxelShape(), this.initialShape,
+                this.minX, this.minY, this.minZ, this.maxX, this.maxY, this.maxZ,
+                cuboids, this.initialCuboidCount, this.cuboidCount + 1);
+    }
+
+    private static boolean isAligned(double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+        return isAligned(minX) && isAligned(minY) && isAligned(minZ) &&
+                isAligned(maxX) && isAligned(maxY) && isAligned(maxZ);
+    }
+
+    private static boolean isAligned(VoxelShape shape) {
+        for (Direction.Axis axis : Direction.Axis.VALUES) {
+            DoubleList coords = shape.getCoords(axis);
+            for (int i = 0, size = coords.size(); i < size; i++) {
+                if (!isAligned(coords.getDouble(i))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static boolean isAligned(double coord) {
+        //multiple of 0.25 and small enough that all box arithmetic on the 0.25 grid is exact
+        double scaled = coord * 4.0;
+        return scaled == Math.rint(scaled) && Math.abs(coord) <= 1.0E9;
+    }
+
+    /**
+     * The shape vanilla would have stored instead of this one, computed by replaying the skipped shape operations.
+     */
+    public VoxelShape materialized() {
+        VoxelShape materialized = this.materialized;
+        if (materialized == null) {
+            materialized = this.initialShape != null ? this.initialShape :
+                    Shapes.create(new AABB(this.minX, this.minY, this.minZ, this.maxX, this.maxY, this.maxZ));
+            double[] cuboids = this.cuboids.elements();
+            for (int i = this.initialCuboidCount * 6, end = this.cuboidCount * 6; i < end; i += 6) {
+                AABB cuboid = new AABB(cuboids[i], cuboids[i + 1], cuboids[i + 2], cuboids[i + 3], cuboids[i + 4], cuboids[i + 5]);
+                materialized = Shapes.joinUnoptimized(materialized, Shapes.create(cuboid), BooleanOp.ONLY_FIRST);
+            }
+            this.materialized = materialized;
+        }
+        return materialized;
+    }
+
+    //Delegate the VoxelShape API to the materialized vanilla shape. Vanilla jigsaw placement never calls any
+    //of these, but mods interacting with the free space shape must observe vanilla behavior.
+    //The protected methods (get, findIndex, isCubeLike, collideX) cannot delegate to another instance, but their
+    //inherited implementations only read this.getCoords(...) and this.shape, which already delegate. The materialized
+    //shape is always an ArrayVoxelShape or Shapes.empty(), which use those same inherited implementations, so the
+    //behavior is identical without overriding them.
+
+    @Override
+    public DoubleList getCoords(Direction.Axis axis) {
+        return this.materialized().getCoords(axis);
+    }
+
+    @Override
+    public double min(Direction.Axis axis) {
+        return this.materialized().min(axis);
+    }
+
+    @Override
+    public double max(Direction.Axis axis) {
+        return this.materialized().max(axis);
+    }
+
+    @Override
+    public AABB bounds() {
+        return this.materialized().bounds();
+    }
+
+    @Override
+    public VoxelShape singleEncompassing() {
+        return this.materialized().singleEncompassing();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.materialized().isEmpty();
+    }
+
+    @Override
+    public VoxelShape move(double x, double y, double z) {
+        return this.materialized().move(x, y, z);
+    }
+
+    @Override
+    public VoxelShape optimize() {
+        return this.materialized().optimize();
+    }
+
+    @Override
+    public void forAllEdges(Shapes.DoubleLineConsumer consumer) {
+        this.materialized().forAllEdges(consumer);
+    }
+
+    @Override
+    public void forAllBoxes(Shapes.DoubleLineConsumer consumer) {
+        this.materialized().forAllBoxes(consumer);
+    }
+
+    @Override
+    public List<AABB> toAabbs() {
+        return this.materialized().toAabbs();
+    }
+
+    @Override
+    public double min(Direction.Axis axis, double primaryPosition, double secondaryPosition) {
+        return this.materialized().min(axis, primaryPosition, secondaryPosition);
+    }
+
+    @Override
+    public double max(Direction.Axis axis, double primaryPosition, double secondaryPosition) {
+        return this.materialized().max(axis, primaryPosition, secondaryPosition);
+    }
+
+    @Override
+    public BlockHitResult clip(Vec3 from, Vec3 to, BlockPos pos) {
+        return this.materialized().clip(from, to, pos);
+    }
+
+    @Override
+    public Optional<Vec3> closestPointTo(Vec3 point) {
+        return this.materialized().closestPointTo(point);
+    }
+
+    @Override
+    public VoxelShape getFaceShape(Direction direction) {
+        return this.materialized().getFaceShape(direction);
+    }
+
+    @Override
+    public double collide(Direction.Axis axis, AABB box, double maxDist) {
+        return this.materialized().collide(axis, box, maxDist);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this.materialized().equals(other);
+    }
+
+    @Override
+    public String toString() {
+        return this.materialized().toString();
+    }
+
+    /**
+     * Placeholder voxel set that delegates to the materialized vanilla shape's voxel set, for code that accesses the
+     * {@link VoxelShape#shape} field of the free space shape directly.
+     */
+    private static class MaterializingDiscreteVoxelShape extends DiscreteVoxelShape {
+        private VoxelShapeCuboidDifference owner;
+
+        MaterializingDiscreteVoxelShape() {
+            super(0, 0, 0);
+        }
+
+        private DiscreteVoxelShape delegate() {
+            return this.owner.materialized().shape;
+        }
+
+        @Override
+        public DiscreteVoxelShape rotate(OctahedralGroup rotation) {
+            return this.delegate().rotate(rotation);
+        }
+
+        @Override
+        public boolean isFullWide(AxisCycle cycle, int x, int y, int z) {
+            return this.delegate().isFullWide(cycle, x, y, z);
+        }
+
+        @Override
+        public boolean isFullWide(int x, int y, int z) {
+            return this.delegate().isFullWide(x, y, z);
+        }
+
+        @Override
+        public boolean isFull(AxisCycle cycle, int x, int y, int z) {
+            return this.delegate().isFull(cycle, x, y, z);
+        }
+
+        @Override
+        public boolean isFull(int x, int y, int z) {
+            return this.delegate().isFull(x, y, z);
+        }
+
+        @Override
+        public void fill(int x, int y, int z) {
+            this.delegate().fill(x, y, z);
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return this.delegate().isEmpty();
+        }
+
+        @Override
+        public int firstFull(Direction.Axis axis) {
+            return this.delegate().firstFull(axis);
+        }
+
+        @Override
+        public int lastFull(Direction.Axis axis) {
+            return this.delegate().lastFull(axis);
+        }
+
+        @Override
+        public int firstFull(Direction.Axis axis, int secondaryPosition, int tertiaryPosition) {
+            return this.delegate().firstFull(axis, secondaryPosition, tertiaryPosition);
+        }
+
+        @Override
+        public int lastFull(Direction.Axis axis, int secondaryPosition, int tertiaryPosition) {
+            return this.delegate().lastFull(axis, secondaryPosition, tertiaryPosition);
+        }
+
+        @Override
+        public int getSize(Direction.Axis axis) {
+            return this.delegate().getSize(axis);
+        }
+
+        @Override
+        public int getXSize() {
+            return this.delegate().getXSize();
+        }
+
+        @Override
+        public int getYSize() {
+            return this.delegate().getYSize();
+        }
+
+        @Override
+        public int getZSize() {
+            return this.delegate().getZSize();
+        }
+
+        @Override
+        public void forAllEdges(DiscreteVoxelShape.IntLineConsumer consumer, boolean combine) {
+            this.delegate().forAllEdges(consumer, combine);
+        }
+
+        @Override
+        public void forAllBoxes(DiscreteVoxelShape.IntLineConsumer consumer, boolean combine) {
+            this.delegate().forAllBoxes(consumer, combine);
+        }
+
+        @Override
+        public void forAllFaces(DiscreteVoxelShape.IntFaceConsumer consumer) {
+            this.delegate().forAllFaces(consumer);
+        }
+    }
+}

--- a/common/src/main/java/net/caffeinemc/mods/lithium/mixin/gen/jigsaw_free_space/JigsawPlacementMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/lithium/mixin/gen/jigsaw_free_space/JigsawPlacementMixin.java
@@ -1,0 +1,28 @@
+package net.caffeinemc.mods.lithium.mixin.gen.jigsaw_free_space;
+
+import net.caffeinemc.mods.lithium.common.shapes.VoxelShapeCuboidDifference;
+import net.minecraft.world.level.levelgen.structure.pools.JigsawPlacement;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(JigsawPlacement.class)
+public class JigsawPlacementMixin {
+
+    /**
+     * Replace the initial free space shape (usually the max-radius box minus the start piece's box) with a
+     * cuboid-list-based representation. The subsequent piece placement queries and free space subtractions in
+     * {@code Placer#tryPlacingChildren} then operate on the cuboid lists directly instead of running vanilla's
+     * costly voxel-based shape joins. If the shape cannot be represented exactly, it is passed through unchanged
+     * and all operations fall back to vanilla.
+     */
+    @ModifyVariable(
+            method = "addPieces(Lnet/minecraft/world/level/levelgen/RandomState;IZLnet/minecraft/world/level/chunk/ChunkGenerator;Lnet/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplateManager;Lnet/minecraft/world/level/LevelHeightAccessor;Lnet/minecraft/util/RandomSource;Lnet/minecraft/core/Registry;Lnet/minecraft/world/level/levelgen/structure/PoolElementStructurePiece;Ljava/util/List;Lnet/minecraft/world/phys/shapes/VoxelShape;Lnet/minecraft/world/level/levelgen/structure/pools/alias/PoolAliasLookup;Lnet/minecraft/world/level/levelgen/structure/templatesystem/LiquidSettings;)V",
+            at = @At("HEAD"),
+            argsOnly = true
+    )
+    private static VoxelShape useCuboidDifferenceFreeSpace(VoxelShape freeSpace) {
+        return VoxelShapeCuboidDifference.tryConvert(freeSpace);
+    }
+}

--- a/common/src/main/java/net/caffeinemc/mods/lithium/mixin/gen/jigsaw_free_space/JigsawPlacementPlacerMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/lithium/mixin/gen/jigsaw_free_space/JigsawPlacementPlacerMixin.java
@@ -1,0 +1,68 @@
+package net.caffeinemc.mods.lithium.mixin.gen.jigsaw_free_space;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.caffeinemc.mods.lithium.common.shapes.VoxelShapeCuboidDifference;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.shapes.BooleanOp;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(targets = "net.minecraft.world.level.levelgen.structure.pools.JigsawPlacement$Placer")
+public class JigsawPlacementPlacerMixin {
+    private static final String TRY_PLACING_CHILDREN = "tryPlacingChildren(Lnet/minecraft/world/level/levelgen/structure/PoolElementStructurePiece;Lorg/apache/commons/lang3/mutable/MutableObject;IZLnet/minecraft/world/level/LevelHeightAccessor;Lnet/minecraft/world/level/levelgen/RandomState;Lnet/minecraft/world/level/levelgen/structure/pools/alias/PoolAliasLookup;Lnet/minecraft/world/level/levelgen/structure/templatesystem/LiquidSettings;)V";
+
+    /**
+     * The free space inside the current piece (used when placing children on the interior of a piece) starts out
+     * as a single cuboid, which the cuboid-list-based representation can express directly.
+     */
+    @WrapOperation(
+            method = TRY_PLACING_CHILDREN,
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/shapes/Shapes;create(Lnet/minecraft/world/phys/AABB;)Lnet/minecraft/world/phys/shapes/VoxelShape;", ordinal = 0)
+    )
+    private VoxelShape createInteriorFreeSpace(AABB cuboid, Operation<VoxelShape> original) {
+        VoxelShape freeSpace = VoxelShapeCuboidDifference.tryCreate(cuboid);
+        if (freeSpace != null) {
+            return freeSpace;
+        }
+        return original.call(cuboid);
+    }
+
+    /**
+     * A candidate piece is rejected when any part of its deflated bounding box lies outside the free space.
+     * For the cuboid-list-based free space this test is a handful of coordinate comparisons instead of a
+     * voxel-based shape join.
+     */
+    @WrapOperation(
+            method = TRY_PLACING_CHILDREN,
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/shapes/Shapes;joinIsNotEmpty(Lnet/minecraft/world/phys/shapes/VoxelShape;Lnet/minecraft/world/phys/shapes/VoxelShape;Lnet/minecraft/world/phys/shapes/BooleanOp;)Z")
+    )
+    private boolean testCandidateOutsideFreeSpace(VoxelShape freeSpace, VoxelShape candidate, BooleanOp op, Operation<Boolean> original) {
+        if (op == BooleanOp.ONLY_SECOND && freeSpace instanceof VoxelShapeCuboidDifference cuboidDifference) {
+            int result = cuboidDifference.exceedsFreeSpace(candidate);
+            if (result != VoxelShapeCuboidDifference.FALLBACK) {
+                return result == VoxelShapeCuboidDifference.EXCEEDS;
+            }
+        }
+        return original.call(VoxelShapeCuboidDifference.unwrap(freeSpace), VoxelShapeCuboidDifference.unwrap(candidate), op);
+    }
+
+    /**
+     * Subtracting a placed piece's bounding box from the free space only appends the cuboid to the list instead
+     * of running a voxel-based shape join.
+     */
+    @WrapOperation(
+            method = TRY_PLACING_CHILDREN,
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/shapes/Shapes;joinUnoptimized(Lnet/minecraft/world/phys/shapes/VoxelShape;Lnet/minecraft/world/phys/shapes/VoxelShape;Lnet/minecraft/world/phys/shapes/BooleanOp;)Lnet/minecraft/world/phys/shapes/VoxelShape;")
+    )
+    private VoxelShape subtractFromFreeSpace(VoxelShape freeSpace, VoxelShape placedPiece, BooleanOp op, Operation<VoxelShape> original) {
+        if (op == BooleanOp.ONLY_FIRST && freeSpace instanceof VoxelShapeCuboidDifference cuboidDifference) {
+            VoxelShape result = cuboidDifference.trySubtract(placedPiece);
+            if (result != null) {
+                return result;
+            }
+        }
+        return original.call(VoxelShapeCuboidDifference.unwrap(freeSpace), VoxelShapeCuboidDifference.unwrap(placedPiece), op);
+    }
+}

--- a/common/src/main/java/net/caffeinemc/mods/lithium/mixin/gen/jigsaw_free_space/package-info.java
+++ b/common/src/main/java/net/caffeinemc/mods/lithium/mixin/gen/jigsaw_free_space/package-info.java
@@ -1,0 +1,4 @@
+@MixinConfigOption(description = "Jigsaw structure placement (e.g. villages, bastions, trial chambers) tracks the remaining free space using cuboid lists instead of repeatedly joining VoxelShapes")
+package net.caffeinemc.mods.lithium.mixin.gen.jigsaw_free_space;
+
+import net.caffeinemc.gradle.MixinConfigOption;

--- a/common/src/main/resources/lithium.mixins.json
+++ b/common/src/main/resources/lithium.mixins.json
@@ -164,6 +164,8 @@
     "experimental.entity.block_caching.suffocation.EntityMixin",
     "experimental.entity.item_entity_merging.ItemEntityMixin",
     "gen.cached_generator_settings.NoiseBasedChunkGeneratorMixin",
+    "gen.jigsaw_free_space.JigsawPlacementMixin",
+    "gen.jigsaw_free_space.JigsawPlacementPlacerMixin",
     "math.fast_blockpos.BlockPosMixin",
     "math.fast_blockpos.DirectionMixin",
     "math.fast_util.AABBMixin",

--- a/fabric/src/test/java/shapes/JigsawFreeSpaceTest.java
+++ b/fabric/src/test/java/shapes/JigsawFreeSpaceTest.java
@@ -1,0 +1,279 @@
+package shapes;
+
+import net.caffeinemc.mods.lithium.common.shapes.VoxelShapeCuboidDifference;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.shapes.BooleanOp;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import util.TestUtils;
+
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Simulates the shape operation sequence of vanilla jigsaw structure placement
+ * ({@code JigsawPlacement.Placer#tryPlacingChildren}) and checks that the {@link VoxelShapeCuboidDifference}
+ * fast paths produce exactly the same results as the vanilla voxel-based shape operations they replace.
+ */
+public class JigsawFreeSpaceTest {
+
+    private static final boolean CAN_INVOKE_VANILLA_CODE = !TestUtils.IS_MIXIN_LOADED;
+
+    private static final int CHAIN_COUNT = 12;
+    private static final int PIECES_PER_CHAIN = 40;
+
+    /**
+     * Mirrors the candidate rejection query of the jigsaw_free_space mixin, including the vanilla fallback.
+     */
+    private static boolean lithiumPieceRejected(VoxelShape freeSpace, VoxelShape candidate) {
+        if (freeSpace instanceof VoxelShapeCuboidDifference cuboidDifference) {
+            int result = cuboidDifference.exceedsFreeSpace(candidate);
+            if (result != VoxelShapeCuboidDifference.FALLBACK) {
+                return result == VoxelShapeCuboidDifference.EXCEEDS;
+            }
+        }
+        return Shapes.joinIsNotEmpty(VoxelShapeCuboidDifference.unwrap(freeSpace), VoxelShapeCuboidDifference.unwrap(candidate), BooleanOp.ONLY_SECOND);
+    }
+
+    /**
+     * Mirrors the free space subtraction of the jigsaw_free_space mixin, including the vanilla fallback.
+     */
+    private static VoxelShape lithiumSubtract(VoxelShape freeSpace, VoxelShape placedPiece) {
+        if (freeSpace instanceof VoxelShapeCuboidDifference cuboidDifference) {
+            VoxelShape result = cuboidDifference.trySubtract(placedPiece);
+            if (result != null) {
+                return result;
+            }
+        }
+        return Shapes.joinUnoptimized(VoxelShapeCuboidDifference.unwrap(freeSpace), VoxelShapeCuboidDifference.unwrap(placedPiece), BooleanOp.ONLY_FIRST);
+    }
+
+    private static void assertShapesEqual(VoxelShape expected, VoxelShape actual, String message) {
+        Assertions.assertEquals(expected.isEmpty(), actual.isEmpty(), () -> message + " (isEmpty)");
+        List<AABB> expectedBoxes = expected.toAabbs();
+        List<AABB> actualBoxes = actual.toAabbs();
+        Assertions.assertEquals(expectedBoxes, actualBoxes, () -> message + " (toAabbs)");
+    }
+
+    private static AABB randomPieceBox(Random random, int radius) {
+        int sizeX = 1 + random.nextInt(8);
+        int sizeY = 1 + random.nextInt(8);
+        int sizeZ = 1 + random.nextInt(8);
+        //also generate boxes that stick out of or lie outside the container
+        int minX = random.nextInt(-radius - 4, radius + 5 - sizeX);
+        int minY = random.nextInt(-radius - 4, radius + 5 - sizeY);
+        int minZ = random.nextInt(-radius - 4, radius + 5 - sizeZ);
+        return new AABB(minX, minY, minZ, minX + sizeX, minY + sizeY, minZ + sizeZ);
+    }
+
+    /**
+     * Runs one simulated placement: both free space representations start from the same initial shape and receive
+     * the same query + subtraction sequence, checking equal results after every step.
+     */
+    private static void runPlacementChain(VoxelShape vanillaFreeSpace, VoxelShape lithiumFreeSpace, Random random, int radius, String testName) {
+        for (int piece = 0; piece < PIECES_PER_CHAIN; piece++) {
+            AABB pieceBox = randomPieceBox(random, radius);
+            String message = testName + ", piece " + piece + ": " + pieceBox;
+            //materializing the lithium shape replays the whole subtraction chain, so only check it occasionally
+            boolean checkMaterialized = piece % 13 == 0 || piece == PIECES_PER_CHAIN - 1;
+
+            VoxelShape deflatedCandidate = Shapes.create(pieceBox.deflate(0.25));
+            boolean vanillaRejected = Shapes.joinIsNotEmpty(vanillaFreeSpace, deflatedCandidate, BooleanOp.ONLY_SECOND);
+            boolean lithiumRejected = lithiumPieceRejected(lithiumFreeSpace, deflatedCandidate);
+            Assertions.assertEquals(vanillaRejected, lithiumRejected, () -> message + " (rejection query)");
+
+            if (checkMaterialized) {
+                //vanilla code unaware of the replaced shape class must see the same shape (exercises the delegation
+                //to the materialized shape, including direct DiscreteVoxelShape accesses inside joinIsNotEmpty)
+                boolean lithiumRejectedVanillaPath = Shapes.joinIsNotEmpty(lithiumFreeSpace, deflatedCandidate, BooleanOp.ONLY_SECOND);
+                Assertions.assertEquals(vanillaRejected, lithiumRejectedVanillaPath, () -> message + " (rejection query via vanilla code)");
+            }
+
+            if (!vanillaRejected) {
+                VoxelShape placedPiece = Shapes.create(pieceBox);
+                vanillaFreeSpace = Shapes.joinUnoptimized(vanillaFreeSpace, placedPiece, BooleanOp.ONLY_FIRST);
+                lithiumFreeSpace = lithiumSubtract(lithiumFreeSpace, placedPiece);
+                if (checkMaterialized) {
+                    assertShapesEqual(vanillaFreeSpace, VoxelShapeCuboidDifference.unwrap(lithiumFreeSpace), message + " (free space after subtraction)");
+                }
+            }
+        }
+        assertShapesEqual(vanillaFreeSpace, VoxelShapeCuboidDifference.unwrap(lithiumFreeSpace), testName + " (final free space)");
+    }
+
+    @Test
+    void testSingleCuboidFreeSpace() {
+        if (!CAN_INVOKE_VANILLA_CODE) {
+            return;
+        }
+        Random random = new Random(TestUtils.SEED);
+        for (int chain = 0; chain < CHAIN_COUNT; chain++) {
+            int radius = 8 + random.nextInt(9);
+            AABB container = new AABB(-radius, -radius, -radius, radius, radius, radius);
+
+            //like the piece interior free space: Shapes.create(AABB.of(pieceBoundingBox))
+            VoxelShape lithiumFreeSpace = VoxelShapeCuboidDifference.tryCreate(container);
+            Assertions.assertNotNull(lithiumFreeSpace, "aligned container must take the fast path");
+
+            runPlacementChain(Shapes.create(container), lithiumFreeSpace, random, radius, "testSingleCuboidFreeSpace, chain " + chain);
+        }
+    }
+
+    @Test
+    void testConvertedFreeSpace() {
+        if (!CAN_INVOKE_VANILLA_CODE) {
+            return;
+        }
+        Random random = new Random(TestUtils.SEED + 1);
+        for (int chain = 0; chain < CHAIN_COUNT; chain++) {
+            int radius = 8 + random.nextInt(9);
+            AABB container = new AABB(-radius, -radius, -radius, radius, radius, radius);
+            AABB startPieceBox = randomPieceBox(random, radius - 4);
+
+            //like the initial jigsaw free space: max range box minus the start piece's box
+            VoxelShape initialFreeSpace = Shapes.join(Shapes.create(container), Shapes.create(startPieceBox), BooleanOp.ONLY_FIRST);
+            VoxelShape lithiumFreeSpace = VoxelShapeCuboidDifference.tryConvert(initialFreeSpace);
+            Assertions.assertInstanceOf(VoxelShapeCuboidDifference.class, lithiumFreeSpace, "aligned initial free space must be converted");
+            assertShapesEqual(initialFreeSpace, VoxelShapeCuboidDifference.unwrap(lithiumFreeSpace), "converted free space");
+
+            runPlacementChain(initialFreeSpace, lithiumFreeSpace, random, radius, "testConvertedFreeSpace, chain " + chain);
+        }
+    }
+
+    @Test
+    void testSharedListDivergence() {
+        if (!CAN_INVOKE_VANILLA_CODE) {
+            return;
+        }
+        //vanilla keeps the free space of the parent piece around and reuses it for multiple children,
+        //so subtracting from the same instance twice (diverging chains) must not corrupt either chain
+        AABB container = new AABB(-16, -16, -16, 16, 16, 16);
+        VoxelShape vanillaBase = Shapes.create(container);
+        VoxelShapeCuboidDifference lithiumBase = VoxelShapeCuboidDifference.tryCreate(container);
+        Assertions.assertNotNull(lithiumBase);
+
+        VoxelShape vanillaCommon = Shapes.joinUnoptimized(vanillaBase, Shapes.create(new AABB(-8, -8, -8, -2, -2, -2)), BooleanOp.ONLY_FIRST);
+        VoxelShape lithiumCommon = lithiumSubtract(lithiumBase, Shapes.create(new AABB(-8, -8, -8, -2, -2, -2)));
+
+        VoxelShape vanillaBranchA = Shapes.joinUnoptimized(vanillaCommon, Shapes.create(new AABB(0, 0, 0, 4, 4, 4)), BooleanOp.ONLY_FIRST);
+        VoxelShape lithiumBranchA = lithiumSubtract(lithiumCommon, Shapes.create(new AABB(0, 0, 0, 4, 4, 4)));
+        VoxelShape vanillaBranchB = Shapes.joinUnoptimized(vanillaCommon, Shapes.create(new AABB(5, 5, 5, 9, 9, 9)), BooleanOp.ONLY_FIRST);
+        VoxelShape lithiumBranchB = lithiumSubtract(lithiumCommon, Shapes.create(new AABB(5, 5, 5, 9, 9, 9)));
+
+        //branch A must not see branch B's subtraction and vice versa
+        VoxelShape candidateInB = Shapes.create(new AABB(5, 5, 5, 9, 9, 9).deflate(0.25));
+        Assertions.assertFalse(lithiumPieceRejected(lithiumBranchA, candidateInB), "branch A must not contain branch B's subtraction");
+        VoxelShape candidateInA = Shapes.create(new AABB(0, 0, 0, 4, 4, 4).deflate(0.25));
+        Assertions.assertFalse(lithiumPieceRejected(lithiumBranchB, candidateInA), "branch B must not contain branch A's subtraction");
+        Assertions.assertTrue(lithiumPieceRejected(lithiumBranchA, candidateInA), "branch A must contain its own subtraction");
+        Assertions.assertTrue(lithiumPieceRejected(lithiumBranchB, candidateInB), "branch B must contain its own subtraction");
+
+        assertShapesEqual(vanillaBranchA, VoxelShapeCuboidDifference.unwrap(lithiumBranchA), "branch A");
+        assertShapesEqual(vanillaBranchB, VoxelShapeCuboidDifference.unwrap(lithiumBranchB), "branch B");
+        assertShapesEqual(vanillaCommon, VoxelShapeCuboidDifference.unwrap(lithiumCommon), "common chain after divergence");
+    }
+
+    @Test
+    void testBoundaryTouchingCandidates() {
+        if (!CAN_INVOKE_VANILLA_CODE) {
+            return;
+        }
+        AABB container = new AABB(0, 0, 0, 16, 16, 16);
+        VoxelShape vanillaFreeSpace = Shapes.create(container);
+        VoxelShapeCuboidDifference lithiumFreeSpace = VoxelShapeCuboidDifference.tryCreate(container);
+        Assertions.assertNotNull(lithiumFreeSpace);
+
+        AABB[] candidates = new AABB[]{
+                new AABB(0, 0, 0, 16, 16, 16), //exactly the container
+                new AABB(0, 0, 0, 16, 16, 16).deflate(0.25), //the container after deflation
+                new AABB(0, 0, 0, 4, 4, 4), //touching the min corner
+                new AABB(12, 12, 12, 16, 16, 16), //touching the max corner
+                new AABB(-0.25, 0, 0, 4, 4, 4), //sticking out by a quarter block
+                new AABB(12, 12, 12, 16.25, 16, 16), //sticking out by a quarter block
+                new AABB(-4, -4, -4, 0, 0, 0), //outside, sharing only the min corner point
+                new AABB(16, 16, 16, 20, 20, 20), //outside, sharing only the max corner point
+                new AABB(-8, -8, -8, -4, -4, -4), //fully outside
+        };
+        for (AABB candidateBox : candidates) {
+            VoxelShape candidate = Shapes.create(candidateBox);
+            boolean vanillaRejected = Shapes.joinIsNotEmpty(vanillaFreeSpace, candidate, BooleanOp.ONLY_SECOND);
+            Assertions.assertEquals(vanillaRejected, lithiumPieceRejected(lithiumFreeSpace, candidate), "candidate " + candidateBox);
+        }
+
+        //subtract a piece and test candidates touching the subtracted piece
+        AABB placedBox = new AABB(4, 4, 4, 8, 8, 8);
+        VoxelShape vanillaSubtracted = Shapes.joinUnoptimized(vanillaFreeSpace, Shapes.create(placedBox), BooleanOp.ONLY_FIRST);
+        VoxelShape lithiumSubtracted = lithiumSubtract(lithiumFreeSpace, Shapes.create(placedBox));
+        AABB[] candidatesAfterSubtraction = new AABB[]{
+                new AABB(8, 4, 4, 12, 8, 8), //sharing a face with the subtracted piece
+                new AABB(8.25, 4, 4, 12, 8, 8), //a quarter block away
+                new AABB(7.75, 4, 4, 12, 8, 8), //overlapping by a quarter block
+                new AABB(8, 8, 8, 12, 12, 12), //sharing only a corner point
+                new AABB(4, 4, 4, 8, 8, 8), //exactly the subtracted piece
+                new AABB(5, 5, 5, 7, 7, 7), //fully inside the subtracted piece
+        };
+        for (AABB candidateBox : candidatesAfterSubtraction) {
+            VoxelShape candidate = Shapes.create(candidateBox);
+            boolean vanillaRejected = Shapes.joinIsNotEmpty(vanillaSubtracted, candidate, BooleanOp.ONLY_SECOND);
+            Assertions.assertEquals(vanillaRejected, lithiumPieceRejected(lithiumSubtracted, candidate), "candidate after subtraction " + candidateBox);
+        }
+    }
+
+    @Test
+    void testFullyCoveredFreeSpace() {
+        if (!CAN_INVOKE_VANILLA_CODE) {
+            return;
+        }
+        AABB container = new AABB(0, 0, 0, 8, 8, 8);
+        VoxelShape vanillaFreeSpace = Shapes.create(container);
+        VoxelShape lithiumFreeSpace = VoxelShapeCuboidDifference.tryCreate(container);
+        Assertions.assertNotNull(lithiumFreeSpace);
+
+        //cover the entire container with two pieces
+        for (AABB placedBox : new AABB[]{new AABB(0, 0, 0, 8, 4, 8), new AABB(0, 4, 0, 8, 8, 8)}) {
+            VoxelShape placedPiece = Shapes.create(placedBox);
+            vanillaFreeSpace = Shapes.joinUnoptimized(vanillaFreeSpace, placedPiece, BooleanOp.ONLY_FIRST);
+            lithiumFreeSpace = lithiumSubtract(lithiumFreeSpace, placedPiece);
+        }
+        assertShapesEqual(vanillaFreeSpace, VoxelShapeCuboidDifference.unwrap(lithiumFreeSpace), "fully covered free space");
+
+        VoxelShape candidate = Shapes.create(new AABB(2, 2, 2, 4, 4, 4).deflate(0.25));
+        boolean vanillaRejected = Shapes.joinIsNotEmpty(vanillaFreeSpace, candidate, BooleanOp.ONLY_SECOND);
+        Assertions.assertTrue(vanillaRejected);
+        Assertions.assertEquals(vanillaRejected, lithiumPieceRejected(lithiumFreeSpace, candidate), "candidate in fully covered free space");
+    }
+
+    @Test
+    void testUnalignedFallback() {
+        if (!CAN_INVOKE_VANILLA_CODE) {
+            return;
+        }
+        //unaligned coordinates must never take the fast paths
+        AABB unalignedContainer = new AABB(0.1, 0, 0, 16, 16, 16);
+        Assertions.assertNull(VoxelShapeCuboidDifference.tryCreate(unalignedContainer), "unaligned container must not take the fast path");
+        VoxelShape unalignedShape = Shapes.create(unalignedContainer);
+        Assertions.assertSame(unalignedShape, VoxelShapeCuboidDifference.tryConvert(unalignedShape), "unaligned free space must not be converted");
+
+        AABB hugeContainer = new AABB(0, 0, 0, 2.0E9, 16, 16);
+        Assertions.assertNull(VoxelShapeCuboidDifference.tryCreate(hugeContainer), "huge container must not take the fast path");
+
+        //unaligned candidates fall back to vanilla behavior on an aligned free space
+        AABB container = new AABB(0, 0, 0, 16, 16, 16);
+        VoxelShapeCuboidDifference lithiumFreeSpace = VoxelShapeCuboidDifference.tryCreate(container);
+        Assertions.assertNotNull(lithiumFreeSpace);
+        VoxelShape vanillaFreeSpace = Shapes.create(container);
+
+        AABB unalignedCandidateBox = new AABB(0.1, 0.1, 0.1, 4, 4, 4);
+        VoxelShape unalignedCandidate = Shapes.create(unalignedCandidateBox);
+        Assertions.assertEquals(VoxelShapeCuboidDifference.FALLBACK, lithiumFreeSpace.exceedsFreeSpace(unalignedCandidate));
+        boolean vanillaRejected = Shapes.joinIsNotEmpty(vanillaFreeSpace, unalignedCandidate, BooleanOp.ONLY_SECOND);
+        Assertions.assertEquals(vanillaRejected, lithiumPieceRejected(lithiumFreeSpace, unalignedCandidate), "unaligned candidate fallback");
+
+        Assertions.assertNull(lithiumFreeSpace.trySubtract(unalignedCandidate), "unaligned piece must not take the subtraction fast path");
+        VoxelShape vanillaSubtracted = Shapes.joinUnoptimized(vanillaFreeSpace, unalignedCandidate, BooleanOp.ONLY_FIRST);
+        VoxelShape lithiumSubtracted = lithiumSubtract(lithiumFreeSpace, unalignedCandidate);
+        assertShapesEqual(vanillaSubtracted, VoxelShapeCuboidDifference.unwrap(lithiumSubtracted), "unaligned piece subtraction fallback");
+    }
+}

--- a/lithium-fabric-mixin-config.md
+++ b/lithium-fabric-mixin-config.md
@@ -441,6 +441,10 @@ Various world generation optimizations
 (default: `true`)  
 World generator settings cache the sea level.
   
+### `mixin.gen.jigsaw_free_space`
+(default: `true`)  
+Jigsaw structure placement (e.g. villages, bastions, trial chambers) tracks the remaining free space using cuboid lists instead of repeatedly joining VoxelShapes
+  
 ### `mixin.math`
 (default: `true`)  
 Various math optimizations


### PR DESCRIPTION
Fixes #235

Jigsaw structure generation spends a lot of time repeatedly combining `VoxelShape` while checking and subtracting free space. This replaces that hot path with a lightweight cuboid-difference representation that avoids building voxel shapes for the common case.

The fast path handles vanilla jigsaw placement exactly while falling back to the original implementation for anything it can't represent (such as off-grid or modded shapes), preserving vanilla behavior.

Added randomized tests that compare the new implementation against vanilla across full placement chains, boundary cases, shared-list divergence, and fallback paths.
