### PR TITLE
Fix target block validation logic in RemoveBlockGoalMixin

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/lithium/mixin/ai/non_poi_block_search/RemoveBlockGoalMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/lithium/mixin/ai/non_poi_block_search/RemoveBlockGoalMixin.java
@@ -48,7 +48,7 @@ public abstract class RemoveBlockGoalMixin extends MoveToBlockGoal implements Li
 
     @Unique
     private static boolean lithium$isValidTargetAbove(ChunkAccess chunkAccess, BlockPos.MutableBlockPos mutable) {
-        return chunkAccess.getBlockState(mutable.move(0, 1, 0)).isAir()
-                && chunkAccess.getBlockState(mutable.move(0, 1, 0)).isAir();
+        return chunkAccess.getBlockState(mutable.above(1)).isAir()
+                && chunkAccess.getBlockState(mutable.above(2)).isAir();
     }
 }


### PR DESCRIPTION
Correct the logic for validating target blocks in the `RemoveBlockGoalMixin` to ensure proper functionality when checking for air blocks above the specified position. This change improves the accuracy of block removal goals.

