### PR TITLE
Fix stale equipment subscriptions when clearing equipment

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/lithium/mixin/entity/equipment_tracking/EntityEquipmentMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/lithium/mixin/entity/equipment_tracking/EntityEquipmentMixin.java
@@ -121,7 +121,7 @@ public class EntityEquipmentMixin implements EquipmentInfo, ChangeSubscriber.Cou
     }
 
     @Inject(
-            method = "clear", at = @At("RETURN")
+            method = "clear", at = @At("HEAD")
     )
     private void updateOnClear(CallbackInfo ci) {
         if (this.inLevel) {


### PR DESCRIPTION
The `EntityEquipment.clear()` injection currently runs at RETURN. At thatpoint, vanilla has already replaced every value in the equipment map with `ItemStack.EMPTY`.

`invalidateData()` iterates over the current equipment values to unsubscribe from the previously equipped stacks. Because those references have already been discarded, `lithium$unsubscribeWithData()` is never called for them.

This leaves old item stacks subscribed to the `EntityEquipment` instance. Changes made later to those stacks may send stale notifications, mark theequipment as changed unnecessarily, and retain tracking references much longer than intended.

<img width="820" height="230" alt="image" src="https://github.com/user-attachments/assets/614dada8-7588-46f7-84db-f22d45c14ae8" />


### Fix

Move the injection point to `HEAD` so `invalidateData()` runs while the old equipment stacks are still available. This ensures that every non-empty stack is unsubscribed before vanilla clears the equipment map.

This also makes the ordering consistent with `setAll()`, which invalidates the old tracking data before replacing the equipment contents.