### PR TITLE
Skip client-side brain write when a sleeping villager dies

### DIFF
--- a/common/src/main/java/net/caffeinemc/mods/lithium/mixin/client_tick/entity/unused_brain/VillagerMixin.java
+++ b/common/src/main/java/net/caffeinemc/mods/lithium/mixin/client_tick/entity/unused_brain/VillagerMixin.java
@@ -1,0 +1,34 @@
+package net.caffeinemc.mods.lithium.mixin.client_tick.entity.unused_brain;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ai.Brain;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.npc.villager.Villager;
+import net.minecraft.world.level.Level;
+import org.jspecify.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(Villager.class)
+public abstract class VillagerMixin extends Entity {
+
+    public VillagerMixin(EntityType<?> type, Level level) {
+        super(type, level);
+    }
+
+    /**
+     * Vanilla writes the LAST_WOKEN memory on both sides: when a sleeping
+     * villager dies, the client's death entity event runs
+     * {@code LivingEntity.die -> Villager.stopSleeping -> Brain.setMemory},
+     * which trips the dummy-brain guard inside packet handling and
+     * disconnects the client.
+     */
+    @WrapWithCondition(
+            method = "stopSleeping", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/ai/Brain;setMemory(Lnet/minecraft/world/entity/ai/memory/MemoryModuleType;Ljava/lang/Object;)V")
+    )
+    private <U> boolean isServerSide(Brain instance, MemoryModuleType<U> type, @Nullable U value) {
+        return !this.level().isClientSide();
+    }
+}

--- a/common/src/main/resources/lithium.mixins.json
+++ b/common/src/main/resources/lithium.mixins.json
@@ -112,6 +112,7 @@
     "chunk.serialization.PalettedContainerMixin",
     "chunk.serialization.SimpleBitStorageMixin",
     "client_tick.entity.unused_brain.AllayMixin",
+    "client_tick.entity.unused_brain.VillagerMixin",
     "collections.attributes.AttributeMapMixin",
     "collections.block_entity_tickers.LevelChunkMixin",
     "collections.brain.BrainMixin",


### PR DESCRIPTION
Closes the residual from #772.

With `mixin.debug=true`, the dummy-brain tripwire still fires a false positive on a vanilla path: when a sleeping villager dies, the client runs `LivingEntity.die` -> `Villager.stopSleeping` -> `Brain.setMemory(LAST_WOKEN, ...)`, and the throw lands inside packet handling, disconnecting the client. In production the write is already cancelled silently, so this only affects debug users, but it is vanilla writing client-side rather than a misbehaving mod, which is what the tripwire is meant to catch.

This adds a `VillagerMixin` guarding the `stopSleeping` write with `@WrapWithCondition`, in the same shape as the existing `AllayMixin` whitelist for `mobInteract`.

Tested:
- `:fabric:build` succeeds. Two optional gametests failed on my machine (`ai_villager_hide_in_home` timeout, `lava_push_speed` timing); the gametest server has no client, so `level().isClientSide()` is always false there and the wrapped call is unconditionally original, which makes those look like pre-existing timing flakes rather than effects of this change.
- The production behavior around the same path was verified live on 26.2 with 0.25.3: killing sleeping villagers disconnects nothing and the entities die normally, unchanged by this patch.
